### PR TITLE
Issue 5: Allowing ingestion of user defined env vars into Bookie containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pr-bookkeeper-operator          1         1         1            1           17s
 
 If the BookKeeper cluster is expected to work with Pravega, we need to create a ConfigMap which needs to have the following values
 
-| PRAVEGA_CLUSTER_NAME | Name of Pravega Cluster using this BookKeeper Vluster |
+| PRAVEGA_CLUSTER_NAME | Name of Pravega Cluster using this BookKeeper Cluster |
 | WAIT_FOR | Zookeeper URL |
 
 The name this ConfigMap needs to be mentioned in the field `envVars` present in the BookKeeper Spec. For more details about this ConfigMap refer to [this](doc/bookkeeper-options.md#bookkeeper-custom-configuration).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ pr-bookkeeper-operator          1         1         1            1           17s
 
 ### Install a sample Bookkeeper cluster
 
-If the BookKeeper cluster is expected to work with Pravega, create a ConfigMap which contains the correct value for the key `PRAVEGA_CLUSTER_NAME`, and provide the name of this file within the field `envVars` present in the BookKeeper Spec. For more details about this ConfigMap refer to [this](doc/bookkeeper-options.md#bookkeeper-custom-configuration).
+If the BookKeeper cluster is expected to work with Pravega, we need to create a ConfigMap which needs to have the following values
+
+| PRAVEGA_CLUSTER_NAME | Name of Pravega Cluster using this BookKeeper Vluster |
+| WAIT_FOR | Zookeeper URL |
+
+The name this ConfigMap needs to be mentioned in the field `envVars` present in the BookKeeper Spec. For more details about this ConfigMap refer to [this](doc/bookkeeper-options.md#bookkeeper-custom-configuration).
 
 Helm can be used to install a sample Bookkeeper cluster.
 
@@ -88,15 +93,15 @@ After a couple of minutes, all cluster members should become ready.
 ```
 $ kubectl get bk
 NAME                   VERSION   DESIRED MEMBERS   READY MEMBERS     AGE
-pravega-bk              0.6.1     3                 3               2m
+pravega-bk             0.6.1     3                 3                 2m
 ```
 
 ```
 $ kubectl get all -l bookkeeper_cluster=pravega-bk
 NAME                                              READY   STATUS    RESTARTS   AGE
-pod/pravega-bk-bookie-0                              1/1     Running   0          2m
-pod/pravega-bk-bookie-1                              1/1     Running   0          2m
-pod/pravega-bk-bookie-2                              1/1     Running   0          2m
+pod/pravega-bk-bookie-0                           1/1     Running   0          2m
+pod/pravega-bk-bookie-1                           1/1     Running   0          2m
+pod/pravega-bk-bookie-2                           1/1     Running   0          2m
 
 NAME                                            TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)              AGE
 service/pravega-bk-bookie-headless              ClusterIP   None          <none>        3181/TCP             2m

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ pr-bookkeeper-operator          1         1         1            1           17s
 
 ### Install a sample Bookkeeper cluster
 
-Use Helm to install a sample Bookkeeper cluster with release name `pravega`.
+If the BookKeeper cluster is expected to work with Pravega, create a ConfigMap which contains the correct value for the key `PRAVEGA_CLUSTER_NAME`, and provide the name of this file within the field `envVars` present in the BookKeeper Spec. For more details about this ConfigMap refer to [this](doc/bookkeeper-options.md#bookkeeper-custom-configuration).
+
+Helm can be used to install a sample Bookkeeper cluster.
 
 ```
 $ helm install charts/bookkeeper --name pravega-bk --set zookeeperUri=[ZOOKEEPER_HOST]
@@ -70,7 +72,6 @@ $ helm install charts/bookkeeper --name pravega-bk --set zookeeperUri=[ZOOKEEPER
 where:
 
 - `[ZOOKEEPER_HOST]` is the host or IP address of your Zookeeper deployment (e.g. `zk-client:2181`). Multiple Zookeeper URIs can be specified, use a comma-separated list and DO NOT leave any spaces in between (e.g. `zk-0:2181,zk-1:2181,zk-2:2181`).
-
 
 Check out the [Bookkeeper Helm Chart](charts/bookkeeper) for more a complete list of installation parameters.
 

--- a/charts/bookkeeper/templates/_helpers.tpl
+++ b/charts/bookkeeper/templates/_helpers.tpl
@@ -14,3 +14,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "configmap.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-configmap" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/bookkeeper/templates/bookkeeper.yaml
+++ b/charts/bookkeeper/templates/bookkeeper.yaml
@@ -2,14 +2,12 @@ apiVersion: "bookkeeper.pravega.io/v1alpha1"
 kind: "BookkeeperCluster"
 metadata:
   name: {{ template "bookkeeper.fullname" . }}
-
 spec:
   replicas: {{ .Values.replicas }}
-
   image:
     repository: {{ with .Values.image }}{{ .repository }}{{ end }}
     pullPolicy: {{ with .Values.image }}{{ .pullPolicy }}{{ end }}
-
+  envVars: {{ template "configmap.fullname" . }}
   version: {{ .Values.version }}
   zookeeperUri: {{ .Values.zookeeperUri }}
   autoRecovery: {{ .Values.autoRecovery }}

--- a/charts/bookkeeper/templates/config_map.yaml
+++ b/charts/bookkeeper/templates/config_map.yaml
@@ -4,5 +4,5 @@ metadata:
   name: {{ template "configmap.fullname" . }}
 data:
   # Configuration values can be set as key-value properties
-  PRAVEGA_CLUSTER_NAME: pravega
+  PRAVEGA_CLUSTER_NAME: {{ .Values.pravegaClusterName }}
   WAIT_FOR: {{ .Values.zookeeperUri }}

--- a/charts/bookkeeper/templates/config_map.yaml
+++ b/charts/bookkeeper/templates/config_map.yaml
@@ -1,0 +1,8 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ template "configmap.fullname" . }}
+data:
+  # Configuration values can be set as key-value properties
+  PRAVEGA_CLUSTER_NAME: pravega
+  WAIT_FOR: {{ .Values.zookeeperUri }}

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -7,5 +7,6 @@ image:
   repository: pravega/bookkeeper
   pullPolicy: IfNotPresent
 version: latest
+pravegaClusterName: pravega
 zookeeperUri: zookeeper-client:2181
 autoRecovery: true

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -2,14 +2,10 @@ apiVersion: "bookkeeper.pravega.io/v1alpha1"
 kind: "BookkeeperCluster"
 metadata:
   name: "pravega-bk"
-
-spec:
-  replicas: 3
-
-  image:
-    repository: pravega/bookkeeper
-    pullPolicy: IfNotPresent
-
-  version: latest
-  zookeeperUri: zookeeper-client:2181
-  autoRecovery: true
+replicas: 3
+image:
+  repository: pravega/bookkeeper
+  pullPolicy: IfNotPresent
+version: latest
+zookeeperUri: zookeeper-client:2181
+autoRecovery: true

--- a/deploy/config_map.yaml
+++ b/deploy/config_map.yaml
@@ -1,0 +1,8 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: bk-config-map
+data:
+  # Configuration values can be set as key-value properties
+  PRAVEGA_CLUSTER_NAME: pravega
+  WAIT_FOR: zookeeper-client:2181

--- a/deploy/crds/cr.yaml
+++ b/deploy/crds/cr.yaml
@@ -12,6 +12,8 @@ spec:
 
   replicas: 3
 
+  envVars: bk-config-map
+
   storage:
       ledgerVolumeClaimTemplate:
         accessModes: [ "ReadWriteOnce" ]

--- a/doc/bookkeeper-options.md
+++ b/doc/bookkeeper-options.md
@@ -81,7 +81,12 @@ Default gcLoggingOpts:
 
 ### BookKeeper Custom Configuration
 
-It is possible to add additional parameters into the BookKeeper container by allowing users to create a custom ConfigMap  and specify its name within the field `EnvVars`of the Bookkeeper Spec. However, the user needs to ensure that the following keys which are present in BookKeeper ConfigMap which is created by the BookKeeper Operator should not be a part of this custom ConfigMap.
+It is possible to add additional parameters into the BookKeeper container by allowing users to create a custom ConfigMap  and specify its name within the field `envVars` of the Bookkeeper Spec. The following values need to be provided within this ConfigMap if we expect the BookKeeper cluster to work with Pravega.
+
+| PRAVEGA_CLUSTER_NAME | Name of Pravega Cluster using this BookKeeper Vluster |
+| WAIT_FOR | Zookeeper URL |
+
+The user however needs to ensure that the following keys which are present in BookKeeper ConfigMap which is created by the BookKeeper Operator should not be a part of this custom ConfigMap.
 
 ```
 - BOOKIE_MEM_OPTS

--- a/doc/bookkeeper-options.md
+++ b/doc/bookkeeper-options.md
@@ -78,3 +78,21 @@ Default gcLoggingOpts:
 "-XX:NumberOfGCLogFiles=5",
 "-XX:GCLogFileSize=64m",
 ```
+
+### BookKeeper Custom Configuration
+
+It is possible to add additional parameters into the BookKeeper container by allowing users to create a custom ConfigMap  and specify its name within the field `EnvVars`of the Bookkeeper Spec. However, the user needs to ensure that the following keys which are present in BookKeeper ConfigMap which is created by the BookKeeper Operator should not be a part of this custom ConfigMap.
+
+```
+- BOOKIE_MEM_OPTS
+- BOOKIE_GC_OPTS
+- BOOKIE_GC_LOGGING_OPTS
+- BOOKIE_EXTRA_OPTS
+- ZK_URL
+- BK_useHostNameAsBookieID
+- PRAVEGA_CLUSTER_NAME
+- WAIT_FOR
+- BK_useHostNameAsBookieID
+- BK_AUTORECOVERY
+- BK_lostBookieRecoveryDelay
+```

--- a/doc/bookkeeper-options.md
+++ b/doc/bookkeeper-options.md
@@ -83,7 +83,7 @@ Default gcLoggingOpts:
 
 It is possible to add additional parameters into the BookKeeper container by allowing users to create a custom ConfigMap  and specify its name within the field `envVars` of the Bookkeeper Spec. The following values need to be provided within this ConfigMap if we expect the BookKeeper cluster to work with Pravega.
 
-| PRAVEGA_CLUSTER_NAME | Name of Pravega Cluster using this BookKeeper Vluster |
+| PRAVEGA_CLUSTER_NAME | Name of Pravega Cluster using this BookKeeper Cluster |
 | WAIT_FOR | Zookeeper URL |
 
 The user however needs to ensure that the following keys which are present in BookKeeper ConfigMap which is created by the BookKeeper Operator should not be a part of this custom ConfigMap.

--- a/doc/bookkeeper-options.md
+++ b/doc/bookkeeper-options.md
@@ -90,8 +90,6 @@ It is possible to add additional parameters into the BookKeeper container by all
 - BOOKIE_EXTRA_OPTS
 - ZK_URL
 - BK_useHostNameAsBookieID
-- PRAVEGA_CLUSTER_NAME
-- WAIT_FOR
 - BK_useHostNameAsBookieID
 - BK_AUTORECOVERY
 - BK_lostBookieRecoveryDelay

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -137,6 +137,10 @@ type BookkeeperClusterSpec struct {
 	// options that is good enough for general deployment.
 	JVMOptions *JVMOptions `json:"jvmOptions"`
 
+	// Provides the name of the configmap created by the user to provide additional key-value pairs
+	// that need to be configured into the bookie pods as environmental variables
+	EnvVars string `json:"envVars,omitempty"`
+
 	// Version is the expected version of the Pravega cluster.
 	// The pravega-operator will eventually make the Pravega cluster version
 	// equal to the expected version.

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -93,7 +93,6 @@ func MakeBookiePodTemplate(p *v1alpha1.BookkeeperCluster) corev1.PodTemplateSpec
 }
 
 func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
-	configMapName := strings.TrimSpace(bk.Spec.EnvVars)
 	environment := []corev1.EnvFromSource{
 		{
 			ConfigMapRef: &corev1.ConfigMapEnvSource{
@@ -104,6 +103,7 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 		},
 	}
 
+	configMapName := strings.TrimSpace(bk.Spec.EnvVars)
 	if configMapName != "" {
 		environment = append(environment, corev1.EnvFromSource{
 			ConfigMapRef: &corev1.ConfigMapEnvSource{
@@ -265,8 +265,6 @@ func MakeBookieConfigMap(bookkeeperCluster *v1alpha1.BookkeeperCluster) *corev1.
 		"BOOKIE_EXTRA_OPTS":        strings.Join(extraOpts, " "),
 		"ZK_URL":                   bookkeeperCluster.Spec.ZookeeperUri,
 		"BK_useHostNameAsBookieID": "true",
-		"PRAVEGA_CLUSTER_NAME":     bookkeeperCluster.ObjectMeta.Name,
-		"WAIT_FOR":                 bookkeeperCluster.Spec.ZookeeperUri,
 	}
 
 	if match, _ := util.CompareVersions(bookkeeperCluster.Spec.Version, "0.5.0", "<"); match {

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -93,6 +93,27 @@ func MakeBookiePodTemplate(p *v1alpha1.BookkeeperCluster) corev1.PodTemplateSpec
 }
 
 func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
+	configMapName := strings.TrimSpace(bk.Spec.EnvVars)
+	environment := []corev1.EnvFromSource{
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: util.ConfigMapNameForBookie(bk.Name),
+				},
+			},
+		},
+	}
+
+	if configMapName != "" {
+		environment = append(environment, corev1.EnvFromSource{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: configMapName,
+				},
+			},
+		})
+	}
+
 	podSpec := &corev1.PodSpec{
 		Containers: []corev1.Container{
 			{
@@ -105,15 +126,7 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 						ContainerPort: 3181,
 					},
 				},
-				EnvFrom: []corev1.EnvFromSource{
-					{
-						ConfigMapRef: &corev1.ConfigMapEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: util.ConfigMapNameForBookie(bk.Name),
-							},
-						},
-					},
-				},
+				EnvFrom: environment,
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      LedgerDiskName,


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
The Bookkeeper Operator should enable ingestion of environment variables into the Bookie container by allowing users to create a custom config map and specify its same within the Bookkeeper Spec.

### Purpose of the change
Fixes #5 

### What the code does
It allows the user to provide the name of the config map `envVars` within the manifest file, which contains all the user defined environment variables that need to be ingested into the Bookie container.

### How to verify it
The key-value pairs that have been added to the config map created by the user should be added to the list of environment variables of the bookkeeper pods.
