### PR TITLE
Issue 18: Adding TestMode flag in charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The project is currently alpha. While no breaking API changes are currently plan
  * [Requirements](#requirements)
  * [Quickstart](#quickstart)    
     * [Install the Operator](#install-the-operator)
+        * [Install the Operator in Test Mode](#install-the-operator-in-test-mode)
     * [Install a sample Bookkeeper Cluster](#install-a-sample-bookkeeper-cluster)
     * [Scale a Bookkeeper Cluster](#scale-a-bookkeeper-cluster)
     * [Upgrade a Bookkeeper Cluster](#upgrade-a-bookkeeper-cluster)
@@ -58,6 +59,9 @@ $ kubectl get deploy
 NAME                          DESIRED   CURRENT   UP-TO-DATE   AVAILABLE     AGE
 pr-bookkeeper-operator           1         1         1            1          17s
 ```
+
+#### Install the Operator in Test Mode
+ The Operator can be run in `test mode` if we want to deploy the Bookkeeper Cluster on minikube or on a cluster with very limited resources by setting `testmode: true` in `values.yaml` file. Operator running in test mode skips the minimum replica requirement checks. Test mode provides a bare minimum setup and is not recommended to be used in production environments.
 
 ### Install a sample Bookkeeper cluster
 
@@ -165,7 +169,7 @@ Check out the [development guide](doc/development.md).
 
 The latest Bookkeeper releases can be found on the [Github Release](https://github.com/pravega/bookkeeper-operator/releases) project page.
 
-## Upgrade the Bookkeeper-Operator
+## Upgrade the Bookkeeper Operator
 Bookkeeper operator can be upgraded by modifying the image tag using
 ```
 $ kubectl edit <operator deployment name>

--- a/charts/bookkeeper-operator/templates/operator.yaml
+++ b/charts/bookkeeper-operator/templates/operator.yaml
@@ -23,6 +23,9 @@ spec:
           name: metrics
         command:
         - bookkeeper-operator
+        {{- if .Values.testmode }}
+        args: [-test]
+        {{- end }}
         env:
         - name: WATCH_NAMESPACE
           valueFrom:

--- a/charts/bookkeeper-operator/values.yaml
+++ b/charts/bookkeeper-operator/values.yaml
@@ -19,3 +19,6 @@ serviceAccount:
 # Whether to create custom resource
 crd:
   create: true
+
+# whether to enable test mode
+testmode: false

--- a/deploy/crds/cr.yaml
+++ b/deploy/crds/cr.yaml
@@ -29,5 +29,12 @@ spec:
           requests:
             storage: 10Gi
 
+      indexVolumeClaimTemplate:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: "standard"
+        resources:
+          requests:
+            storage: 10Gi
+
   autoRecovery: true
   version: 0.7.0

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -1,6 +1,7 @@
 ## Manual installation
 
 * [Install the Operator manually](#install-the-operator-manually)
+  * [Install the Operator in Test Mode](#install-the-operator-in-test-mode)
 * [Install the Bookkeeper cluster manually](#install-the-bookkeeper-cluster-manually)
 * [Uninstall the Bookkeeper Cluster manually](#uninstall-the-bookkeeper-cluster-manually)
 * [Uninstall the Operator manually](#uninstall-the-operator-manually)
@@ -34,6 +35,23 @@ Finally create a ConfigMap which contains the list of supported upgrade paths fo
 ```
 $ kubectl create -f deploy/version_map.yaml
 ```
+
+#### Install the Operator in Test Mode
+The operator can be deployed in `test mode` by providing the argument `-test` inside the `operator.yaml` file in the following way.
+
+```
+containers:
+  - name: bookkeeper-operator
+    image: pravega/bookkeeper-operator:latest
+    ports:
+    - containerPort: 60000
+      name: metrics
+    command:
+    - bookkeeper-operator
+    imagePullPolicy: Always
+    args: [-test]
+```
+For more details check [this](../README.md#install-the-operator-in-test-mode)
 
 ### Install the Bookkeeper cluster manually
 

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -11,7 +11,7 @@
 package v1alpha1
 
 import (
-	"github.com/pravega/pravega-operator/pkg/controller/config"
+	"github.com/pravega/bookkeeper-operator/pkg/controller/config"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -13,6 +13,4 @@ package config
 // TestMode enables test mode in the operator and applies
 // the following changes:
 // - Disables BookKeeper minimum number of replicas
-// - Disables Pravega Controller minimum number of replicas
-// - Disables Segment Store minimum number of replicas
 var TestMode bool


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
To add a `testmode` flag so that user can run operator in test mode if required.

### Purpose of the change
Fixes #18 

### What the code does
Adds a flag `testmode` in values.yaml file, so that user can run operator in test mode if required, which skips the minimum replica requirement checks on bookkeeper instances.

### How to verify it
With these changes user will be able to deploy the operator in test mode by changing `deploy/operator.yaml` file during manual installation and by changing `charts/bookkeeper-operator/values.yaml` while installing via charts.
