### PR TITLE
Support for custom storage class for Bookkeeper volume

### DIFF
--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -45,3 +45,4 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 | `image.pullPolicy` | Pull policy for Bookkeeper image | `IfNotPresent` |
 | `replicas` | Replicas for Bookkeeper | `3` |
 | `autoRecovery`| Enable Bookkeeper autoRecovery | `true` |
+| `storage.className` | Storage class for Bookkeeper volume | `standard` |

--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -45,4 +45,4 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 | `image.pullPolicy` | Pull policy for Bookkeeper image | `IfNotPresent` |
 | `replicas` | Replicas for Bookkeeper | `3` |
 | `autoRecovery`| Enable Bookkeeper autoRecovery | `true` |
-| `storage.className` | Storage class for Bookkeeper volume | `standard` |
+| `storage.className` | Storage class for Bookkeeper volumes | `standard` |

--- a/charts/bookkeeper/templates/bookkeeper.yaml
+++ b/charts/bookkeeper/templates/bookkeeper.yaml
@@ -12,9 +12,23 @@ spec:
   zookeeperUri: {{ .Values.zookeeperUri }}
   autoRecovery: {{ .Values.autoRecovery }}
   storage:
-    ledgerVolumeClaimTemplate:
-      storageClassName: {{ .Values.storage.className }}
-    journalVolumeClaimTemplate:
-      storageClassName: {{ .Values.storage.className }}
-    indexVolumeClaimTemplate:
-      storageClassName: {{ .Values.storage.className }}
+      ledgerVolumeClaimTemplate:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.storage.className }}
+        resources:
+          requests:
+            storage: 10Gi
+
+      journalVolumeClaimTemplate:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.storage.className }}
+        resources:
+          requests:
+            storage: 10Gi
+
+      indexVolumeClaimTemplate:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.storage.className }}
+        resources:
+          requests:
+            storage: 10Gi

--- a/charts/bookkeeper/templates/bookkeeper.yaml
+++ b/charts/bookkeeper/templates/bookkeeper.yaml
@@ -11,3 +11,10 @@ spec:
   version: {{ .Values.version }}
   zookeeperUri: {{ .Values.zookeeperUri }}
   autoRecovery: {{ .Values.autoRecovery }}
+  storage:
+    ledgerVolumeClaimTemplate:
+      storageClassName: {{ .Values.storage.className }}
+    journalVolumeClaimTemplate:
+      storageClassName: {{ .Values.storage.className }}
+    indexVolumeClaimTemplate:
+      storageClassName: {{ .Values.storage.className }}

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -10,3 +10,5 @@ version: 0.7.0
 pravegaClusterName: pravega
 zookeeperUri: zookeeper-client:2181
 autoRecovery: true
+storage:
+  className: standard


### PR DESCRIPTION
### Change log description

In January 2020 I merged change to support custom storage classes for zookeeper and bookkeeper in pravega-operator (https://github.com/pravega/pravega-operator/pull/313). Now that bookkeeper installation was moved to separate repository/operator, we need the same changes.

### Purpose of the change

Need to specify custom storage class for Bookkeeper volume.

### What the code does

Helm chart was modified to allow user to specify custom storage class.

### How to verify it

Run installation with and without custom storage class. The change was tested.
