### PR TITLE
Issue 23: Deploying Bookkeeper Cluster in a different namespace

### DIFF
--- a/charts/bookkeeper-operator/Chart.yaml
+++ b/charts/bookkeeper-operator/Chart.yaml
@@ -1,6 +1,6 @@
 name: bookkeeper-operator
-version: 0.1.0
-appVersion: 0.1.0
+version: latest
+appVersion: latest
 description: bookkeeper operator Helm chart for Kubernetes
 keywords:
 - pravega

--- a/charts/bookkeeper-operator/templates/clusterrole.yaml
+++ b/charts/bookkeeper-operator/templates/clusterrole.yaml
@@ -5,23 +5,46 @@ metadata:
   name: {{ template "bookkeeper-operator.fullname" . }}
 rules:
 - apiGroups:
-  - pravega.pravega.io
-  resources:
-  - "*"
-  verbs:
-  - "*"
-- apiGroups:
   - ""
   resources:
   - nodes
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
   verbs:
   - get
   - watch
   - list
+  - create
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
   - "*"
   verbs:
   - '*'
+- apiGroups:
+  - bookkeeper.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"
 {{- end }}

--- a/charts/bookkeeper-operator/templates/operator.yaml
+++ b/charts/bookkeeper-operator/templates/operator.yaml
@@ -28,9 +28,7 @@ spec:
         {{- end }}
         env:
         - name: WATCH_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: {{ .Values.watchNamespace }}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/charts/bookkeeper-operator/values.yaml
+++ b/charts/bookkeeper-operator/values.yaml
@@ -22,3 +22,7 @@ crd:
 
 # whether to enable test mode
 testmode: false
+
+# Specifies which namespace the Operator should watch for new ClusterResource resources
+# Default: "" == Watch ALL namespaces
+watchNamespace: ""

--- a/charts/bookkeeper/Chart.yaml
+++ b/charts/bookkeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: pravega-bk
-version: 0.6.1
-appVersion: 0.6.1
+version: 0.7.0
+appVersion: 0.7.0
 description: Bookkeeper Helm chart for Kubernetes
 keywords:
   - log storage

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -25,9 +25,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -54,13 +54,42 @@ rules:
   - ""
   resources:
   - nodes
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
   verbs:
   - get
   - watch
   - list
+  - create
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
   - "*"
   verbs:
   - '*'
+- apiGroups:
+  - bookkeeper.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
The change enables the Bookkeeper Operator to deploy a Bookkeeper Cluster in a different namespace.

### Purpose of the change
Fixes #23 

### What the code does
Sets the `WATCH_NAMESPACE` of the Bookeeper Operator to `""` which enables it to deploy a Bookkeeper Cluster in a different namespace. Also adds the necessary cluster-roles to create this deployment.

### How to verify it
Try to deploy a Bookkeeper Cluster in a different namespace `bk` by adding the following within the bookkeeper manifest file
```
metadata:
 name: "pravega-bk"
 namespace: "bk"
```
The Bookkeeper Cluster will get deployed in the specified namespace
```
$ kubectl get po -A
NAMESPACE     NAME                                        READY   STATUS      RESTARTS   AGE
default       bookkeeper-operator-6f68cb6df-2mstv         1/1     Running     0          87m
bk            pravega-bk-bookie-0                         1/1     Running     0          41m
bk            pravega-bk-bookie-1                         1/1     Running     0          41m
bk            pravega-bk-bookie-2                         1/1     Running     0          41m
```

