### PR TITLE
Issue 25: Handling znode deletion

### DIFF
--- a/charts/bookkeeper/templates/_helpers.tpl
+++ b/charts/bookkeeper/templates/_helpers.tpl
@@ -17,7 +17,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "configmap.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-configmap" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-config-map" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "versionmap.fullname" -}}

--- a/deploy/crds/cr.yaml
+++ b/deploy/crds/cr.yaml
@@ -7,7 +7,6 @@ spec:
 
   image:
       repository: pravega/bookkeeper
-      tag: latest
       pullPolicy: IfNotPresent
 
   replicas: 3

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -141,6 +141,9 @@ type BookkeeperClusterSpec struct {
 	// that need to be configured into the bookie pods as environmental variables
 	EnvVars string `json:"envVars,omitempty"`
 
+	// PravegaClusterName is the name of the pravega cluster that thie bookkeeper cluser connects to
+	PravegaClusterName string `json:"pravegaClusterName,omitempty"`
+
 	// Version is the expected version of the Pravega cluster.
 	// The pravega-operator will eventually make the Pravega cluster version
 	// equal to the expected version.

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -264,7 +264,6 @@ func MakeBookieConfigMap(bookkeeperCluster *v1alpha1.BookkeeperCluster) *corev1.
 		"BOOKIE_GC_LOGGING_OPTS":   strings.Join(gcLoggingOpts, " "),
 		"BOOKIE_EXTRA_OPTS":        strings.Join(extraOpts, " "),
 		"ZK_URL":                   bookkeeperCluster.Spec.ZookeeperUri,
-		"BK_CLUSTER_NAME":          bookkeeperCluster.Name,
 		"BK_useHostNameAsBookieID": "true",
 	}
 

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -264,6 +264,7 @@ func MakeBookieConfigMap(bookkeeperCluster *v1alpha1.BookkeeperCluster) *corev1.
 		"BOOKIE_GC_LOGGING_OPTS":   strings.Join(gcLoggingOpts, " "),
 		"BOOKIE_EXTRA_OPTS":        strings.Join(extraOpts, " "),
 		"ZK_URL":                   bookkeeperCluster.Spec.ZookeeperUri,
+		"BK_CLUSTER_NAME":          bookkeeperCluster.Name,
 		"BK_useHostNameAsBookieID": "true",
 	}
 

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -13,6 +13,7 @@ package util
 import (
 	"container/list"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/pravega/bookkeeper-operator/pkg/apis/bookkeeper/v1alpha1"
@@ -34,7 +35,7 @@ func DeleteAllZnodes(bk *v1alpha1.BookkeeperCluster) (err error) {
 	}
 	defer conn.Close()
 
-	root := fmt.Sprintf("/%s/%s", PravegaPath, bk.Name)
+	root := fmt.Sprintf("/%s/%s", PravegaPath, bk.Spec.PravegaClusterName)
 	exist, _, err := conn.Exists(root)
 	if err != nil {
 		return fmt.Errorf("failed to check if zookeeper path exists: %v", err)
@@ -54,6 +55,8 @@ func DeleteAllZnodes(bk *v1alpha1.BookkeeperCluster) (err error) {
 			}
 			tree.Remove(tree.Back())
 		}
+	} else {
+		log.Println("zookeeper path does not exist")
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
*BK_CLUSTER_NAME* which is used by the bookkeeper entrypoint.sh to set the *BK_LEDGERS_PATH* and *BK_CLUSTER_ROOT_PATH* does not reflect the correct value because of which these path are not set correctly.

### Purpose of the change
Fixes #25 

### What the code does
It adds *BK_CLUSTER_NAME* as an environment variable for the bookkeeper pods. This value is picked up by the bookkeeper entrypoint.sh in order to pick the appropriate values for *BK_LEDGERS_PATH* and *BK_CLUSTER_ROOT_PATH*.

### How to verify it
Deletion of znodes should happen as expected after Bookkeeper Cluster deletion.
