### PR TITLE
Issue 25: Handling znode deletion

### DIFF
--- a/charts/bookkeeper/templates/_helpers.tpl
+++ b/charts/bookkeeper/templates/_helpers.tpl
@@ -19,8 +19,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s-configmap" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{- define "versionmap.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-supported-upgrade-paths" .Release.Name $name -}}
-{{- end -}}

--- a/deploy/crds/crd.yaml
+++ b/deploy/crds/crd.yaml
@@ -19,7 +19,7 @@ spec:
   - name: Desired Version
     type: string
     description: The desired bookkeeper version
-    JSONPath: .status.TargetVersion
+    JSONPath: .spec.version
   - name: Desired Members
     type: integer
     description: The number of desired bookkeeper members

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
@@ -241,13 +241,14 @@ func (r *ReconcileBookkeeperCluster) reconcileFinalizers(bk *bookkeeperv1alpha1.
 			configMap := &corev1.ConfigMap{}
 			if strings.TrimSpace(bk.Spec.EnvVars) != "" {
 				err = r.client.Get(context.TODO(), types.NamespacedName{Name: strings.TrimSpace(bk.Spec.EnvVars), Namespace: bk.Namespace}, configMap)
-				if err == nil {
-					clusterName, ok := configMap.Data["PRAVEGA_CLUSTER_NAME"]
-					if ok {
-						// appending name of pravega cluster to the name of the finalizer
-						// to handle zk metadata deletion
-						finalizer = finalizer + "_" + clusterName
-					}
+				if err != nil {
+					return fmt.Errorf("failed to get the configmap %s: %v", bk.Spec.EnvVars, err)
+				}
+				clusterName, ok := configMap.Data["PRAVEGA_CLUSTER_NAME"]
+				if ok {
+					// appending name of pravega cluster to the name of the finalizer
+					// to handle zk metadata deletion
+					finalizer = finalizer + "_" + clusterName
 				}
 			}
 			bk.ObjectMeta.Finalizers = append(bk.ObjectMeta.Finalizers, finalizer)

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
@@ -257,7 +257,7 @@ func (r *ReconcileBookkeeperCluster) reconcileFinalizers(bk *bookkeeperv1alpha1.
 			finalizer := util.GetString(bk.ObjectMeta.Finalizers, util.ZkFinalizer)
 			pravegaClusterName := strings.Replace(finalizer, util.ZkFinalizer, "", 1)
 			if pravegaClusterName == "" {
-				pravegaClusterName = "pravega"
+				pravegaClusterName = "pravega-cluster"
 			} else {
 				pravegaClusterName = strings.Replace(pravegaClusterName, "_", "", 1)
 			}
@@ -281,7 +281,6 @@ func (r *ReconcileBookkeeperCluster) cleanUpZookeeperMeta(bk *bookkeeperv1alpha1
 	if err = util.DeleteAllZnodes(bk, pravegaClusterName); err != nil {
 		return fmt.Errorf("failed to delete zookeeper znodes for (%s): %v", bk.Name, err)
 	}
-	fmt.Println("zookeeper metadata deleted")
 	return nil
 }
 

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
@@ -257,14 +257,11 @@ func (r *ReconcileBookkeeperCluster) reconcileFinalizers(bk *bookkeeperv1alpha1.
 			if value != "" {
 				pravegaClusterName = strings.Replace(value, "PRAVEGA_CLUSTER_NAME", "", 1)
 				bk.ObjectMeta.Finalizers = util.RemoveString(bk.ObjectMeta.Finalizers, value)
-
 			}
 			bk.ObjectMeta.Finalizers = util.RemoveString(bk.ObjectMeta.Finalizers, util.ZkFinalizer)
-
 			if err = r.client.Update(context.TODO(), bk); err != nil {
 				return fmt.Errorf("failed to update Bookkeeper object (%s): %v", bk.Name, err)
 			}
-
 			if err = r.cleanUpZookeeperMeta(bk, pravegaClusterName); err != nil {
 				return fmt.Errorf("failed to clean up metadata (%s): %v", bk.Name, err)
 			}

--- a/pkg/util/bookkeepercluster.go
+++ b/pkg/util/bookkeepercluster.go
@@ -90,7 +90,7 @@ func Min(x, y int32) int32 {
 
 func ContainsString(slice []string, str string) bool {
 	for _, item := range slice {
-		if item == str {
+		if strings.HasPrefix(item, str) {
 			return true
 		}
 	}

--- a/pkg/util/bookkeepercluster.go
+++ b/pkg/util/bookkeepercluster.go
@@ -107,6 +107,15 @@ func RemoveString(slice []string, str string) (result []string) {
 	return result
 }
 
+func GetString(slice []string, str string) (result string) {
+	for _, item := range slice {
+		if strings.HasPrefix(item, str) {
+			return item
+		}
+	}
+	return ""
+}
+
 func GetClusterExpectedSize(p *v1alpha1.BookkeeperCluster) (size int) {
 	return int(p.Spec.Replicas)
 }

--- a/pkg/util/bookkeepercluster.go
+++ b/pkg/util/bookkeepercluster.go
@@ -88,7 +88,7 @@ func Min(x, y int32) int32 {
 	return x
 }
 
-func ContainsString(slice []string, str string) bool {
+func ContainsStringWithPrefix(slice []string, str string) bool {
 	for _, item := range slice {
 		if strings.HasPrefix(item, str) {
 			return true
@@ -107,7 +107,7 @@ func RemoveString(slice []string, str string) (result []string) {
 	return result
 }
 
-func GetString(slice []string, str string) (result string) {
+func GetStringWithPrefix(slice []string, str string) (result string) {
 	for _, item := range slice {
 		if strings.HasPrefix(item, str) {
 			return item

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -11,11 +11,8 @@
 package util
 
 import (
-	"bufio"
 	"container/list"
 	"fmt"
-	"log"
-	"os"
 	"time"
 
 	"github.com/pravega/bookkeeper-operator/pkg/apis/bookkeeper/v1alpha1"
@@ -24,13 +21,12 @@ import (
 
 const (
 	// Set in https://github.com/pravega/bookkeeper/blob/master/docker/bookkeeper/entrypoint.sh#L21
-	PravegaPath      = "pravega"
-	ZkFinalizer      = "cleanUpZookeeper"
-	PravegaMountPath = "/tmp/pravega"
+	PravegaPath = "pravega"
+	ZkFinalizer = "cleanUpZookeeper"
 )
 
 // Delete all znodes related to a specific Bookkeeper cluster
-func DeleteAllZnodes(bk *v1alpha1.BookkeeperCluster) (err error) {
+func DeleteAllZnodes(bk *v1alpha1.BookkeeperCluster, pravegaClusterName string) (err error) {
 	host := []string{bk.Spec.ZookeeperUri}
 	conn, _, err := zk.Connect(host, time.Second*5)
 	if err != nil {
@@ -38,30 +34,25 @@ func DeleteAllZnodes(bk *v1alpha1.BookkeeperCluster) (err error) {
 	}
 	defer conn.Close()
 
-	pravegaClusterName, err := getClusterName(PravegaMountPath)
+	root := fmt.Sprintf("/%s/%s", PravegaPath, pravegaClusterName)
+	exist, _, err := conn.Exists(root)
 	if err != nil {
-		log.Println(err)
-	} else {
-		root := fmt.Sprintf("/%s/%s", PravegaPath, pravegaClusterName)
-		exist, _, err := conn.Exists(root)
+		return fmt.Errorf("failed to check if zookeeper path exists: %v", err)
+	}
+
+	if exist {
+		// Construct BFS tree to delete all znodes recursively
+		tree, err := ListSubTreeBFS(conn, root)
 		if err != nil {
-			return fmt.Errorf("failed to check if zookeeper path exists: %v", err)
+			return fmt.Errorf("failed to construct BFS tree: %v", err)
 		}
 
-		if exist {
-			// Construct BFS tree to delete all znodes recursively
-			tree, err := ListSubTreeBFS(conn, root)
+		for tree.Len() != 0 {
+			err := conn.Delete(tree.Back().Value.(string), -1)
 			if err != nil {
-				return fmt.Errorf("failed to construct BFS tree: %v", err)
+				return fmt.Errorf("failed to delete znode (%s): %v", tree.Back().Value.(string), err)
 			}
-
-			for tree.Len() != 0 {
-				err := conn.Delete(tree.Back().Value.(string), -1)
-				if err != nil {
-					return fmt.Errorf("failed to delete znode (%s): %v", tree.Back().Value.(string), err)
-				}
-				tree.Remove(tree.Back())
-			}
+			tree.Remove(tree.Back())
 		}
 	}
 	return nil
@@ -92,18 +83,4 @@ func ListSubTreeBFS(conn *zk.Conn, root string) (*list.List, error) {
 		queue.Remove(node)
 	}
 	return tree, nil
-}
-
-func getClusterName(filename string) (string, error) {
-	value := ""
-	file, err := os.Open(filename)
-	if err != nil {
-		return value, err
-	}
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		value = scanner.Text()
-	}
-	file.Close()
-	return value, nil
 }

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -13,6 +13,7 @@ package util
 import (
 	"container/list"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/pravega/bookkeeper-operator/pkg/apis/bookkeeper/v1alpha1"
@@ -54,6 +55,9 @@ func DeleteAllZnodes(bk *v1alpha1.BookkeeperCluster, pravegaClusterName string) 
 			}
 			tree.Remove(tree.Back())
 		}
+		log.Println("zookeeper metadata deleted")
+	} else {
+		log.Println("zookeeper metadata not found")
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
*PRAVEGA_CLUSTER_NAME* is required to be set in order to delete znodes, but this value is not being correctly set.

### Purpose of the change
Fixes #25 

### What the code does
It appends the value of *PRAVEGA_CLUSTER_NAME* to the name of the finalizer. This value is then read from the finalizer name at the time of deleting the znodes. 
It also populates the *DESIRED VERSION* field within the bookkeeper crd with the correct value.

### How to verify it
Deletion of znodes should happen as expected after Bookkeeper Cluster deletion.
The following scenarios were tested :-
- Configmap is provided with the name of pravega cluster - In this case the pravega cluster name is appended to the finalizer name and the value is retrieved from this field at the time of zk metadata deletion
- The field `EnvVars` is empty - In this case the pravega cluster name is defaulted to the value `pravega-cluster` and zk metadata is deleted from this path (since if *PRAVEGA_CLUSTER_NAME* is not added as an environment variable to the bk pods, the value of this field is defaulted to `pravega-cluster` inside the bookkeeper entrypoint.sh script)
- The field `EnvVars` contains config map name but this config map is not present - In this case the pravega pods go into an error state
