### PR TITLE
Deprecated configmap name pattern.

### DIFF
--- a/charts/bookkeeper/templates/_helpers.tpl
+++ b/charts/bookkeeper/templates/_helpers.tpl
@@ -22,5 +22,5 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "versionmap.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-supported-versions-map" .Release.Name $name -}}
+{{- printf "%s-%s-supported-upgrade-paths" .Release.Name $name -}}
 {{- end -}}

--- a/charts/bookkeeper/templates/_helpers.tpl
+++ b/charts/bookkeeper/templates/_helpers.tpl
@@ -22,5 +22,5 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "versionmap.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-supported-upgrade-paths" .Release.Name $name -}}
+{{- printf "%s-%s-supported-versions-map" .Release.Name $name -}}
 {{- end -}}


### PR DESCRIPTION
### Change log description
_Fix pattern for name of configuration map for Book Keeper cluster upgrade paths:_ `%s-%s-%s-%s-supported-upgrade-paths` -> `$s-$s-supported-versions-map` ([charts/bookkeeper/templates/_helpers.tpl)](https://github.com/pravega/bookkeeper-operator/blob/master/charts/bookkeeper/templates/_helpers.tpl)

### Purpose of the change

I wasn't able to deploy BookKeeper cluster due to block of operator's admission webhook.
```
helm install bk-operator bookkeeper-operator/charts/bookkeeper-operator
kubectl create -f https://raw.githubusercontent.com/pravega/bookkeeper-operator/master/deploy/version_map.yaml
kubectl create -f bookkeeper.yml
Error from server: error when creating "bookkeeper.yml": admission webhook "bookkeeper-webhook.pravega.io" denied the request: config map bookkeeper-supported-upgrade-paths not found. Please create this config map first and then retry
``` 
Note that `bookkeeper.yml` is the manifest for Book Keeper cluster.

### What the code does

Fixes name of the configuration map pattern which seems to be changed in [this commit](https://github.com/pravega/bookkeeper-operator/commit/5d46ea4f10ee00e9f0d857dcce9bcee16f08f955).

### How to verify it

1. Check out into the branch and build docker image. Alternatively, you could the one I've created following the [development guide](https://github.com/pravega/pravega-operator/blob/master/doc/development.md): `andreykoltsov/bookkeeper-operator:test`.
Then deploy BookKeeper operator using this image via either `--set` option and manual change of values.yaml.

```
$ git clone https://github.com/pravega/bookkeeper-operator.git
$ cd bookkeeper-operator
$  vi charts/bookkeeper-operator/values.yaml
```

Apply the following change either with my image or yours:
```
...
image:
  repository: andreykoltsov/bookkeeper-operator
  tag: test
  pullPolicy: IfNotPresent
...
```

2. Install Book Keeper operator on cluster.

```
$  helm install bk-op bookkeeper-operator/charts/bookkeeper-operator
$ kubectl create -f https://raw.githubusercontent.com/pravega/bookkeeper-operator/master/deploy/version_map.yaml
```

3. Deploy BookKeeper cluster. I've attached manifest from the [example folder](https://github.com/pravega/bookkeeper-operator/blob/master/example/cr-detailed.yaml) of the repo. Make sure to have ZooKeeper deployed.
```
$ kubectl create -f https://raw.githubusercontent.com/pravega/bookkeeper-operator/master/example/cr-detailed.yaml
```