### PR TITLE
Issue 6: Publish events for metadata cleanup failure

### DIFF
--- a/charts/app/bookkeeper-cluster.yaml
+++ b/charts/app/bookkeeper-cluster.yaml
@@ -1,0 +1,41 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: "bookkeeper-cluster"
+  labels:
+    product: "streamingdata"
+    app.kubernetes.io/name: "bookkeeper-cluster"
+  annotations:
+    com.dellemc.kahm.subscribed: "true"
+    nautilus.dellemc.com/chart-version: "latest"
+spec:
+  assemblyPhase: "Pending"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "bookkeeper-cluster"
+  componentKinds:
+    - group: core
+      kind: Service
+    - group: core
+      kind: Pod
+    - group: apps
+      kind: StatefulSet
+    - group: core
+      kind: ConfigMap
+    - group: core
+      kind: Secret
+    - group: core
+      kind: PersistentVolumeClaim
+    - group: core
+      kind: ServiceAccount
+    - group: pravega.pravega.io
+      kind: BookkeeperCluster
+  descriptor:
+    type: "bookkeeper-cluster"
+    version: "latest"
+    description: >
+      Bookkeeper deployment on Kubernetes
+    keywords:
+      - "nautilus"
+      - "pravega"
+      - "bookkeeper"

--- a/charts/app/crd.yaml
+++ b/charts/app/crd.yaml
@@ -1,0 +1,268 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  generation: 1
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: applications.app.k8s.io
+  selfLink: /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/applications.app.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: app.k8s.io
+  names:
+    kind: Application
+    listKind: ApplicationList
+    plural: applications
+    singular: application
+  preserveUnknownFields: true
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            assemblyPhase:
+              type: string
+            componentKinds:
+              items:
+                type: object
+              type: array
+            descriptor:
+              properties:
+                description:
+                  type: string
+                icons:
+                  items:
+                    properties:
+                      size:
+                        type: string
+                      src:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - src
+                    type: object
+                  type: array
+                keywords:
+                  items:
+                    type: string
+                  type: array
+                links:
+                  items:
+                    properties:
+                      description:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  type: array
+                maintainers:
+                  items:
+                    properties:
+                      email:
+                        type: string
+                      name:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  type: array
+                notes:
+                  type: string
+                owners:
+                  items:
+                    properties:
+                      email:
+                        type: string
+                      name:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  type: array
+                type:
+                  type: string
+                version:
+                  type: string
+              type: object
+            info:
+              items:
+                properties:
+                  name:
+                    type: string
+                  type:
+                    type: string
+                  value:
+                    type: string
+                  valueFrom:
+                    properties:
+                      configMapKeyRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          key:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      ingressRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          host:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          path:
+                            type: string
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      secretKeyRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          key:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      serviceRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          path:
+                            type: string
+                          port:
+                            format: int32
+                            type: integer
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      type:
+                        type: string
+                    type: object
+                type: object
+              type: array
+            selector:
+              type: object
+          type: object
+        status:
+          properties:
+            components:
+              items:
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  link:
+                    type: string
+                  name:
+                    type: string
+                  status:
+                    type: string
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: Application
+    listKind: ApplicationList
+    plural: applications
+    singular: application
+  conditions:
+  - lastTransitionTime: "2020-03-27T01:59:25Z"
+    message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - lastTransitionTime: null
+    message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established
+  - lastTransitionTime: "2020-03-27T01:59:25Z"
+    message: 'spec.validation.openAPIV3Schema.type: Required value: must not be empty
+      at the root'
+    reason: Violations
+    status: "True"
+    type: NonStructuralSchema
+  storedVersions:
+  - v1beta1

--- a/pkg/apis/bookkeeper/v1alpha1/status.go
+++ b/pkg/apis/bookkeeper/v1alpha1/status.go
@@ -26,9 +26,9 @@ const (
 	ClusterConditionError                          = "Error"
 
 	// Reasons for cluster upgrading condition
-	UpdatingBookkeeperReason   = "Updating Bookkeeper"
-	UpgradeErrorReason         = "Upgrade Error"
-	RollbackErrorReason        = "Rollback Error"
+	UpdatingBookkeeperReason = "Updating Bookkeeper"
+	UpgradeErrorReason       = "Upgrade Error"
+	RollbackErrorReason      = "Rollback Error"
 )
 
 // BookkeeperClusterStatus defines the observed state of BookkeeperCluster

--- a/pkg/apis/bookkeeper/v1alpha1/status.go
+++ b/pkg/apis/bookkeeper/v1alpha1/status.go
@@ -26,8 +26,6 @@ const (
 	ClusterConditionError                          = "Error"
 
 	// Reasons for cluster upgrading condition
-	UpdatingControllerReason   = "Updating Controller"
-	UpdatingSegmentstoreReason = "Updating Segmentstore"
 	UpdatingBookkeeperReason   = "Updating Bookkeeper"
 	UpgradeErrorReason         = "Upgrade Error"
 	RollbackErrorReason        = "Rollback Error"

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
@@ -266,11 +266,11 @@ func (r *ReconcileBookkeeperCluster) reconcileFinalizers(bk *bookkeeperv1alpha1.
 			}
 			if err = r.cleanUpZookeeperMeta(bk, pravegaClusterName); err != nil {
 				// emit an event for zk metadata cleanup failure
-				message := fmt.Sprintf("failed to clean up metadata (%s): %v", bk.Name, err)
-				event := util.NewEvent("CLEANUP_ERROR", bk, "ZK Metadata Cleanup Failed", message, "Error")
+				message := fmt.Sprintf("failed to cleanup %s metadata from zookeeper (znode path: \"/pravega/%s\"): %v", bk.Name, pravegaClusterName, err)
+				event := util.NewEvent("ZKMETA_CLEANUP_ERROR", bk, "ZK Metadata Cleanup Failed", message, "Error")
 				pubErr := r.client.Create(context.TODO(), event)
 				if pubErr != nil {
-					log.Printf("Error publishing metadata cleanup failure event to k8s. %v", pubErr)
+					log.Printf("Error publishing zk metadata cleanup failure event to k8s. %v", pubErr)
 				}
 				return fmt.Errorf(message)
 			}

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
@@ -266,8 +266,8 @@ func (r *ReconcileBookkeeperCluster) reconcileFinalizers(bk *bookkeeperv1alpha1.
 			}
 			if err = r.cleanUpZookeeperMeta(bk, pravegaClusterName); err != nil {
 				// emit an event for zk metadata cleanup failure
-				message := fmt.Sprintf("failed to cleanup %s metadata from zookeeper (znode path: \"/pravega/%s\"): %v", bk.Name, pravegaClusterName, err)
-				event := util.NewEvent("ZKMETA_CLEANUP_ERROR", bk, "ZK Metadata Cleanup Failed", message, "Error")
+				message := fmt.Sprintf("failed to cleanup %s metadata from zookeeper (znode path: /pravega/%s): %v", bk.Name, pravegaClusterName, err)
+				event := util.NewApplicationEvent("ZKMETA_CLEANUP_ERROR", bk, "ZK Metadata Cleanup Failed", message, "Error")
 				pubErr := r.client.Create(context.TODO(), event)
 				if pubErr != nil {
 					log.Printf("Error publishing zk metadata cleanup failure event to k8s. %v", pubErr)

--- a/pkg/util/k8sutil.go
+++ b/pkg/util/k8sutil.go
@@ -127,11 +127,12 @@ func IsPodFaulty(pod *corev1.Pod) (bool, error) {
 func NewEvent(name string, p *v1alpha1.BookkeeperCluster, reason string, message string, eventType string) *corev1.Event {
 	now := metav1.Now()
 	operatorName, _ := k8s.GetOperatorName()
+	generateName := name + "-"
 	event := corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: p.Namespace,
-			Labels:    LabelsForBookkeeperCluster(p),
+			GenerateName: generateName,
+			Namespace:    p.Namespace,
+			Labels:       LabelsForBookkeeperCluster(p),
 		},
 		InvolvedObject: corev1.ObjectReference{
 			APIVersion:      "bookkeeper.pravega.io/v1alpha1",
@@ -155,11 +156,12 @@ func NewEvent(name string, p *v1alpha1.BookkeeperCluster, reason string, message
 func NewApplicationEvent(name string, p *v1alpha1.BookkeeperCluster, reason string, message string, eventType string) *corev1.Event {
 	now := metav1.Now()
 	operatorName, _ := k8s.GetOperatorName()
+	generateName := name + "-"
 	event := corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: p.Namespace,
-			Labels:    LabelsForBookkeeperCluster(p),
+			GenerateName: generateName,
+			Namespace:    p.Namespace,
+			Labels:       LabelsForBookkeeperCluster(p),
 		},
 		InvolvedObject: corev1.ObjectReference{
 			APIVersion: "app.k8s.io/v1beta1",

--- a/pkg/util/k8sutil.go
+++ b/pkg/util/k8sutil.go
@@ -151,3 +151,30 @@ func NewEvent(name string, p *v1alpha1.BookkeeperCluster, reason string, message
 	}
 	return &event
 }
+
+
+func NewApplicationEvent(name string, p *v1alpha1.BookkeeperCluster, reason string, message string, eventType string) *corev1.Event {
+	now := metav1.Now()
+	operatorName, _ := k8s.GetOperatorName()
+	event := corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: p.Namespace,
+			Labels:    LabelsForBookkeeperCluster(p),
+		},
+		InvolvedObject: corev1.ObjectReference{
+			APIVersion:      "app.k8s.io/v1beta1",
+			Kind:            "Application",
+			Name:            "bookkeeper-cluster",
+			Namespace:       p.GetNamespace(),
+		},
+		Reason:              reason,
+		Message:             message,
+		FirstTimestamp:      now,
+		LastTimestamp:       now,
+		Type:                eventType,
+		ReportingController: operatorName,
+		ReportingInstance:   os.Getenv("POD_NAME"),
+	}
+	return &event
+}

--- a/pkg/util/k8sutil.go
+++ b/pkg/util/k8sutil.go
@@ -152,7 +152,6 @@ func NewEvent(name string, p *v1alpha1.BookkeeperCluster, reason string, message
 	return &event
 }
 
-
 func NewApplicationEvent(name string, p *v1alpha1.BookkeeperCluster, reason string, message string, eventType string) *corev1.Event {
 	now := metav1.Now()
 	operatorName, _ := k8s.GetOperatorName()
@@ -163,10 +162,10 @@ func NewApplicationEvent(name string, p *v1alpha1.BookkeeperCluster, reason stri
 			Labels:    LabelsForBookkeeperCluster(p),
 		},
 		InvolvedObject: corev1.ObjectReference{
-			APIVersion:      "app.k8s.io/v1beta1",
-			Kind:            "Application",
-			Name:            "bookkeeper-cluster",
-			Namespace:       p.GetNamespace(),
+			APIVersion: "app.k8s.io/v1beta1",
+			Kind:       "Application",
+			Name:       "bookkeeper-cluster",
+			Namespace:  p.GetNamespace(),
 		},
 		Reason:              reason,
 		Message:             message,


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
This change enables the Bookkeeper Operator to emit a K8s Event for failure to cleanup BK metadata from zookeeper at the time of Bookkeeper cluster deletion.

### Purpose of the change
Fixes #6 

### What the code does
The code creates an event and publishes it to the k8s event queue if there is a failure in cleaning up the metadata from the zookeeper nodes after deletion of the bookkeeper cluster.

### How to verify it
An event should get added to kubernetes event queue, whenever zookeeper metadata fails to cleanup after bookkeeper cluster deletion.
The following is the describe output of the event that is created.
```
Name:             ZKMETA_CLEANUP_ERROR-nn6sd
Namespace:        default
Labels:           app=bookkeeper-cluster
                  bookkeeper_cluster=pravega-bk
Annotations:      <none>
API Version:      v1
Event Time:       <nil>
First Timestamp:  2020-04-27T16:53:34Z
Involved Object:
  API Version:   app.k8s.io/v1beta1
  Kind:          Application
  Name:          bookkeeper-cluster
  Namespace:     default
Kind:            Event
Last Timestamp:  2020-04-27T16:53:34Z
Message:         failed to cleanup pravega-bk metadata from zookeeper (znode path: /pravega/pravega): failed to delete zookeeper znodes for (pravega-bk): failed to connect to zookeeper: lookup zookeeper-client on 10.100.200.2:53: no such host
Metadata:
  Creation Timestamp:  2020-04-27T16:53:34Z
  Generate Name:       ZKMETA_CLEANUP_ERROR-
  Resource Version:    864342
  Self Link:           /api/v1/namespaces/default/events/ZKMETA_CLEANUP_ERROR-nn6sd
  UID:                 5b4c3f80-36b5-43e6-b417-7992bc309218
Reason:                ZK Metadata Cleanup Failed
Reporting Component:   bookkeeper-operator
Reporting Instance:    bookkeeper-operator-6769886978-xsjx6
Source:
Type:    Error
Events:  <none>
```

Also verified that the event was indeed consumed by KAHM. 
The call to the KAHM REST API (http://10.243.55.90:17999/v1/api/events?appname=bookkeeper-cluster) returned the following response :
```
[
    {
        "id": "bookkeeper-cluster-default-ZKMETA_CLEANUP_ERROR-nn6sd",
        "type": "Error",
        "message": "failed to cleanup pravega-bk metadata from zookeeper (znode path: /pravega/pravega): failed to delete zookeeper znodes for (pravega-bk): failed to connect to zookeeper: lookup zookeeper-client on 10.100.200.2:53: no such host",
        "reason": "ZK Metadata Cleanup Failed",
        "appname": "bookkeeper-cluster",
        "namespace": "default",
        "acknowledged": "false",
        "labels": {
            "app": "bookkeeper-cluster",
            "app.kubernetes.io/name": "bookkeeper-cluster",
            "bookkeeper_cluster": "pravega-bk"
        },
        "createdon": "2020-04-27 16:53:34 +0000 UTC"
    }
]
```