### PR TITLE
Issue 34: Handling znode deletion in non-default namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ pr-bookkeeper-operator           1         1         1            1          17s
  The Operator can be run in `test mode` if we want to deploy the Bookkeeper Cluster on minikube or on a cluster with very limited resources by setting `testmode: true` in `values.yaml` file. Operator running in test mode skips the minimum replica requirement checks. Test mode provides a bare minimum setup and is not recommended to be used in production environments.
 
 ### Install a sample Bookkeeper cluster
+> Note that the Bookkeeper cluster must be installed in the same namespace as the Zookeeper cluster.
 
 If the BookKeeper cluster is expected to work with Pravega, we need to create a ConfigMap which needs to have the following values
 
@@ -82,7 +83,7 @@ $ helm install charts/bookkeeper --name pravega-bk --set zookeeperUri=[ZOOKEEPER
 
 where:
 
-- `[ZOOKEEPER_HOST]` is the host or IP address of your Zookeeper deployment (e.g. `zookeeper-client:2181`). Multiple Zookeeper URIs can be specified, use a comma-separated list and DO NOT leave any spaces in between (e.g. `zookeeper-0:2181,zookeeper-1:2181,zookeeper-2:2181`).
+- `[ZOOKEEPER_HOST]` is the Zookeeper service endpoint of your Zookeeper deployment (e.g. `zookeeper-client:2181`). It expects the zookeeper service URL in the given format `<service-name>:<port-number>`
 
 Check out the [Bookkeeper Helm Chart](charts/bookkeeper) for more a complete list of installation parameters.
 

--- a/README.md
+++ b/README.md
@@ -145,13 +145,14 @@ $ helm delete pravega-bk --purge
 ### Uninstall the Operator
 > Note that the Bookkeeper clusters managed by the Bookkeeper operator will NOT be deleted even if the operator is uninstalled.
 
-```
-$ helm delete pr --purge
-```
 If you want to delete the Bookkeeper cluster, make sure to do it before uninstalling the operator. Also, once the Bookkeeper cluster has been deleted, make sure to check that the zookeeper metadata has been cleaned up before proceeding with the deletion of the operator. This can be confirmed with the presence of the following log message in the operator logs.
-
 ```
 zookeeper metadata deleted
+```
+
+You can then delete the operator
+```
+$ helm delete pr --purge
 ```
 
 ### Manual installation

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -54,6 +54,7 @@ containers:
 For more details check [this](../README.md#install-the-operator-in-test-mode)
 
 ### Install the Bookkeeper cluster manually
+> Note that the Bookkeeper cluster must be installed in the same namespace as the Zookeeper cluster.
 
 If the BookKeeper cluster is expected to work with Pravega, we need to create a ConfigMap which needs to have the following values
 
@@ -89,7 +90,7 @@ spec:
 
 where:
 
-- `[ZOOKEEPER_HOST]` is the host or IP address of your Zookeeper deployment.
+- `[ZOOKEEPER_HOST]` is the Zookeeper service endpoint of your Zookeeper deployment (e.g. `zookeeper-client:2181`). It expects the zookeeper service URL in the given format `<service-name>:<port-number>`
 
 Check out other sample CR files in the [`example`](../example) directory.
 
@@ -117,8 +118,12 @@ $ kubectl delete -f bookkeeper.yaml
 
 > Note that the Bookkeeper cluster managed by the Bookkeeper operator will NOT be deleted even if the operator is uninstalled.
 
-To delete all clusters, delete all cluster CR objects before uninstalling the operator.
+If you want to delete the Bookkeeper cluster, make sure to do it before uninstalling the operator (to delete all clusters, delete all cluster CR objects before uninstalling the operator). Also, once the Bookkeeper cluster has been deleted, make sure to check that the zookeeper metadata has been cleaned up before proceeding with the deletion of the operator. This can be confirmed with the presence of the following log message in the operator logs.
+```
+zookeeper metadata deleted
+```
 
+You can then delete the operator
 ```
 $ kubectl delete -f deploy
 ```

--- a/pkg/util/k8sutil.go
+++ b/pkg/util/k8sutil.go
@@ -82,6 +82,7 @@ func PodAntiAffinity(component string, clusterName string) *corev1.Affinity {
 // Wait for pods in cluster to be terminated
 func WaitForClusterToTerminate(kubeClient client.Client, p *v1alpha1.BookkeeperCluster) (err error) {
 	listOptions := &client.ListOptions{
+		Namespace:     p.Namespace,
 		LabelSelector: labels.SelectorFromSet(LabelsForBookkeeperCluster(p)),
 	}
 

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -14,8 +14,8 @@ import (
 	"container/list"
 	"fmt"
 	"log"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/pravega/bookkeeper-operator/pkg/apis/bookkeeper/v1alpha1"
 	"github.com/samuel/go-zookeeper/zk"

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -44,7 +44,7 @@ func DeleteAllZnodes(bk *v1alpha1.BookkeeperCluster, pravegaClusterName string) 
 	host := []string{hostname}
 	conn, _, err := zk.Connect(host, time.Second*5)
 	if err != nil {
-		return fmt.Errorf("failed to connect to zookeeper: %v", err)
+		return fmt.Errorf("failed to connect to zookeeper (%s): %v", hostname, err)
 	}
 	defer conn.Close()
 

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -32,9 +32,13 @@ func DeleteAllZnodes(bk *v1alpha1.BookkeeperCluster, pravegaClusterName string) 
 	zkUri := strings.Split(bk.Spec.ZookeeperUri, ":")
 	zkSvcName := ""
 	zkSvcPort := ""
-	if len(zkUri) == 2 {
+	if len(zkUri) >= 1 {
 		zkSvcName = zkUri[0]
-		zkSvcPort = zkUri[1]
+		if len(zkUri) == 1 {
+			zkSvcPort = "2181"
+		} else {
+			zkSvcPort = zkUri[1]
+		}
 	}
 	hostname := zkSvcName + "." + bk.Namespace + ".svc.cluster.local:" + zkSvcPort
 	host := []string{hostname}

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"log"
 	"time"
+	"strings"
 
 	"github.com/pravega/bookkeeper-operator/pkg/apis/bookkeeper/v1alpha1"
 	"github.com/samuel/go-zookeeper/zk"
@@ -28,7 +29,15 @@ const (
 
 // Delete all znodes related to a specific Bookkeeper cluster
 func DeleteAllZnodes(bk *v1alpha1.BookkeeperCluster, pravegaClusterName string) (err error) {
-	host := []string{bk.Spec.ZookeeperUri}
+	zkUri := strings.Split(bk.Spec.ZookeeperUri, ":")
+	zkSvcName := ""
+	zkSvcPort := ""
+	if len(zkUri) == 2 {
+		zkSvcName = zkUri[0]
+		zkSvcPort = zkUri[1]
+	}
+	hostname := zkSvcName + "." + bk.Namespace + ".svc.cluster.local:" + zkSvcPort
+	host := []string{hostname}
 	conn, _, err := zk.Connect(host, time.Second*5)
 	if err != nil {
 		return fmt.Errorf("failed to connect to zookeeper: %v", err)


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
The bookkeeper operator fails to delete metadata from zookeeper pods when the bookkeeper cluster is deployed in a non-default namespace.

### Purpose of the change
Fixes #34 

### What the code does
It changes the zookeeper url as the operator is unable to resolve it when the svc is presrent in a different namespaces.

### How to verify it
When the bookkeeper cluster which is deployed in a non-default namespace is deleted, the metadata from zookeeper will be successfully deleted which can be confirmed by finding the message `zookeeper metadata deleted` within the bookkeeper operator logs. 
The bookkeeper operator logs post bookkeepr cluster deletion will look like
```
time="2020-04-28T13:15:37Z" level=info msg="Reconciling BookkeeperCluster new/boo-pravega-bk\n"
time="2020-04-28T13:16:07Z" level=info msg="Reconciling BookkeeperCluster new/boo-pravega-bk\n"
time="2020-04-28T13:16:37Z" level=info msg="Reconciling BookkeeperCluster new/boo-pravega-bk\n"
time="2020-04-28T13:16:59Z" level=info msg="Reconciling BookkeeperCluster new/boo-pravega-bk\n"
time="2020-04-28T13:16:59Z" level=info msg="Webhook is handling incoming requests"
time="2020-04-28T13:16:59Z" level=info msg="Webhook is handling incoming requests"
2020/04/28 13:17:44 Connected to 10.100.200.170:2181
2020/04/28 13:17:44 Authenticated: id=216201252599235700, timeout=5000
2020/04/28 13:17:44 Re-submitting `0` credentials after reconnect
2020/04/28 13:17:44 zookeeper metadata deleted
```