### PR TITLE
Issue 45: Create PVCs in cluster namespace

### DIFF
--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -31,16 +31,16 @@ const (
 	heapDumpDir     = "/tmp/dumpfile/heap"
 )
 
-func MakeBookieHeadlessService(bookkeeperCluster *v1alpha1.BookkeeperCluster) *corev1.Service {
+func MakeBookieHeadlessService(bk *v1alpha1.BookkeeperCluster) *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      util.HeadlessServiceNameForBookie(bookkeeperCluster.Name),
-			Namespace: bookkeeperCluster.Namespace,
-			Labels:    util.LabelsForBookie(bookkeeperCluster),
+			Name:      util.HeadlessServiceNameForBookie(bk.Name),
+			Namespace: bk.Namespace,
+			Labels:    util.LabelsForBookie(bk),
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
@@ -49,46 +49,46 @@ func MakeBookieHeadlessService(bookkeeperCluster *v1alpha1.BookkeeperCluster) *c
 					Port: 3181,
 				},
 			},
-			Selector:  util.LabelsForBookie(bookkeeperCluster),
+			Selector:  util.LabelsForBookie(bk),
 			ClusterIP: corev1.ClusterIPNone,
 		},
 	}
 }
 
-func MakeBookieStatefulSet(bookkeeperCluster *v1alpha1.BookkeeperCluster) *appsv1.StatefulSet {
+func MakeBookieStatefulSet(bk *v1alpha1.BookkeeperCluster) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      util.StatefulSetNameForBookie(bookkeeperCluster.Name),
-			Namespace: bookkeeperCluster.Namespace,
-			Labels:    util.LabelsForBookie(bookkeeperCluster),
+			Name:      util.StatefulSetNameForBookie(bk.Name),
+			Namespace: bk.Namespace,
+			Labels:    util.LabelsForBookie(bk),
 		},
 		Spec: appsv1.StatefulSetSpec{
-			ServiceName:         util.HeadlessServiceNameForBookie(bookkeeperCluster.Name),
-			Replicas:            &bookkeeperCluster.Spec.Replicas,
+			ServiceName:         util.HeadlessServiceNameForBookie(bk.Name),
+			Replicas:            &bk.Spec.Replicas,
 			PodManagementPolicy: appsv1.ParallelPodManagement,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.OnDeleteStatefulSetStrategyType,
 			},
-			Template: MakeBookiePodTemplate(bookkeeperCluster),
+			Template: MakeBookiePodTemplate(bk),
 			Selector: &metav1.LabelSelector{
-				MatchLabels: util.LabelsForBookie(bookkeeperCluster),
+				MatchLabels: util.LabelsForBookie(bk),
 			},
-			VolumeClaimTemplates: makeBookieVolumeClaimTemplates(bookkeeperCluster.Spec.Storage),
+			VolumeClaimTemplates: makeBookieVolumeClaimTemplates(bk),
 		},
 	}
 }
 
-func MakeBookiePodTemplate(p *v1alpha1.BookkeeperCluster) corev1.PodTemplateSpec {
+func MakeBookiePodTemplate(bk *v1alpha1.BookkeeperCluster) corev1.PodTemplateSpec {
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      util.LabelsForBookie(p),
-			Annotations: map[string]string{"bookkeeper.version": p.Spec.Version},
+			Labels:      util.LabelsForBookie(bk),
+			Annotations: map[string]string{"bookkeeper.version": bk.Spec.Version},
 		},
-		Spec: *makeBookiePodSpec(p),
+		Spec: *makeBookiePodSpec(bk),
 	}
 }
 
@@ -191,30 +191,33 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 	return podSpec
 }
 
-func makeBookieVolumeClaimTemplates(spec *v1alpha1.BookkeeperStorageSpec) []corev1.PersistentVolumeClaim {
+func makeBookieVolumeClaimTemplates(bk *v1alpha1.BookkeeperCluster) []corev1.PersistentVolumeClaim {
 	return []corev1.PersistentVolumeClaim{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: JournalDiskName,
+				Name:      JournalDiskName,
+				Namespace: bk.Namespace,
 			},
-			Spec: *spec.JournalVolumeClaimTemplate,
+			Spec: *bk.Spec.Storage.JournalVolumeClaimTemplate,
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: LedgerDiskName,
+				Name:      LedgerDiskName,
+				Namespace: bk.Namespace,
 			},
-			Spec: *spec.LedgerVolumeClaimTemplate,
+			Spec: *bk.Spec.Storage.LedgerVolumeClaimTemplate,
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: IndexDiskName,
+				Name:      IndexDiskName,
+				Namespace: bk.Namespace,
 			},
-			Spec: *spec.IndexVolumeClaimTemplate,
+			Spec: *bk.Spec.Storage.IndexVolumeClaimTemplate,
 		},
 	}
 }
 
-func MakeBookieConfigMap(bookkeeperCluster *v1alpha1.BookkeeperCluster) *corev1.ConfigMap {
+func MakeBookieConfigMap(bk *v1alpha1.BookkeeperCluster) *corev1.ConfigMap {
 	memoryOpts := []string{
 		"-Xms1g",
 		"-XX:MaxDirectMemorySize=1g",
@@ -227,7 +230,7 @@ func MakeBookieConfigMap(bookkeeperCluster *v1alpha1.BookkeeperCluster) *corev1.
 		"-XX:MaxRAMFraction=2",
 	}
 
-	memoryOpts = util.OverrideDefaultJVMOptions(memoryOpts, bookkeeperCluster.Spec.JVMOptions.MemoryOpts)
+	memoryOpts = util.OverrideDefaultJVMOptions(memoryOpts, bk.Spec.JVMOptions.MemoryOpts)
 
 	gcOpts := []string{
 		"-XX:+UseG1GC",
@@ -241,7 +244,7 @@ func MakeBookieConfigMap(bookkeeperCluster *v1alpha1.BookkeeperCluster) *corev1.
 		"-XX:+DisableExplicitGC",
 		"-XX:-ResizePLAB",
 	}
-	gcOpts = util.OverrideDefaultJVMOptions(gcOpts, bookkeeperCluster.Spec.JVMOptions.GcOpts)
+	gcOpts = util.OverrideDefaultJVMOptions(gcOpts, bk.Spec.JVMOptions.GcOpts)
 
 	gcLoggingOpts := []string{
 		"-XX:+PrintGCDetails",
@@ -251,11 +254,11 @@ func MakeBookieConfigMap(bookkeeperCluster *v1alpha1.BookkeeperCluster) *corev1.
 		"-XX:NumberOfGCLogFiles=5",
 		"-XX:GCLogFileSize=64m",
 	}
-	gcLoggingOpts = util.OverrideDefaultJVMOptions(gcLoggingOpts, bookkeeperCluster.Spec.JVMOptions.GcLoggingOpts)
+	gcLoggingOpts = util.OverrideDefaultJVMOptions(gcLoggingOpts, bk.Spec.JVMOptions.GcLoggingOpts)
 
 	extraOpts := []string{}
-	if bookkeeperCluster.Spec.JVMOptions.ExtraOpts != nil {
-		extraOpts = bookkeeperCluster.Spec.JVMOptions.ExtraOpts
+	if bk.Spec.JVMOptions.ExtraOpts != nil {
+		extraOpts = bk.Spec.JVMOptions.ExtraOpts
 	}
 
 	configData := map[string]string{
@@ -263,24 +266,24 @@ func MakeBookieConfigMap(bookkeeperCluster *v1alpha1.BookkeeperCluster) *corev1.
 		"BOOKIE_GC_OPTS":           strings.Join(gcOpts, " "),
 		"BOOKIE_GC_LOGGING_OPTS":   strings.Join(gcLoggingOpts, " "),
 		"BOOKIE_EXTRA_OPTS":        strings.Join(extraOpts, " "),
-		"ZK_URL":                   bookkeeperCluster.Spec.ZookeeperUri,
+		"ZK_URL":                   bk.Spec.ZookeeperUri,
 		"BK_useHostNameAsBookieID": "true",
 	}
 
-	if match, _ := util.CompareVersions(bookkeeperCluster.Spec.Version, "0.5.0", "<"); match {
+	if match, _ := util.CompareVersions(bk.Spec.Version, "0.5.0", "<"); match {
 		// bookkeeper < 0.5 uses BookKeeper 4.5, which does not play well
 		// with hostnames that resolve to different IP addresses over time
 		configData["BK_useHostNameAsBookieID"] = "false"
 	}
 
-	if *bookkeeperCluster.Spec.AutoRecovery {
+	if *bk.Spec.AutoRecovery {
 		configData["BK_AUTORECOVERY"] = "true"
 		// Wait one minute before starting autorecovery. This will give
 		// pods some time to come up after being updated or migrated
 		configData["BK_lostBookieRecoveryDelay"] = "60"
 	}
 
-	for k, v := range bookkeeperCluster.Spec.Options {
+	for k, v := range bk.Spec.Options {
 		prefixKey := fmt.Sprintf("BK_%s", k)
 		configData[prefixKey] = v
 	}
@@ -291,14 +294,14 @@ func MakeBookieConfigMap(bookkeeperCluster *v1alpha1.BookkeeperCluster) *corev1.
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      util.ConfigMapNameForBookie(bookkeeperCluster.Name),
-			Namespace: bookkeeperCluster.ObjectMeta.Namespace,
+			Name:      util.ConfigMapNameForBookie(bk.Name),
+			Namespace: bk.ObjectMeta.Namespace,
 		},
 		Data: configData,
 	}
 }
 
-func MakeBookiePodDisruptionBudget(bookkeeperCluster *v1alpha1.BookkeeperCluster) *policyv1beta1.PodDisruptionBudget {
+func MakeBookiePodDisruptionBudget(bk *v1alpha1.BookkeeperCluster) *policyv1beta1.PodDisruptionBudget {
 	maxUnavailable := intstr.FromInt(1)
 	return &policyv1beta1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
@@ -306,13 +309,13 @@ func MakeBookiePodDisruptionBudget(bookkeeperCluster *v1alpha1.BookkeeperCluster
 			APIVersion: "policy/v1beta1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      util.PdbNameForBookie(bookkeeperCluster.Name),
-			Namespace: bookkeeperCluster.Namespace,
+			Name:      util.PdbNameForBookie(bk.Name),
+			Namespace: bk.Namespace,
 		},
 		Spec: policyv1beta1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &maxUnavailable,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: util.LabelsForBookie(bookkeeperCluster),
+				MatchLabels: util.LabelsForBookie(bk),
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
While creating the VolumeClaimTemplates for the Bookkeeper StatefulSet, the namespace of these PVCs is not explicitly set to that of the Bookkeeper Cluster.

### Purpose of the change
Fixes #45 

### What the code does
Creates Bookkeeper VolumeClaimTemplates in the same namespace as the Bookkeeper Cluster

### How to verify it
Created the bookkeeper cluster in the namespace `new`.
Verified that the PVC is created in the same namespace as the bookkeeper cluster
```
$ kubectl describe pvc index-pravega-bk-bookie-0 -n new
Name:          index-pravega-bk-bookie-0
Namespace:     new
StorageClass:  standard
Status:        Bound
Volume:        pvc-a4cf9134-469b-4650-9ea7-ef447c0787fd
Labels:        app=bookkeeper-cluster
               bookkeeper_cluster=pravega-bk
               component=bookie
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/vsphere-volume
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      10Gi
Access Modes:  RWO
VolumeMode:    Filesystem
```