### PR TITLE
Issue 12: BK_AUTORECOVERY environment variable set by the operator does not take effect

### DIFF
--- a/doc/bookkeeper-options.md
+++ b/doc/bookkeeper-options.md
@@ -95,7 +95,6 @@ The user however needs to ensure that the following keys which are present in Bo
 - BOOKIE_EXTRA_OPTS
 - ZK_URL
 - BK_useHostNameAsBookieID
-- BK_useHostNameAsBookieID
-- BK_AUTORECOVERY
+- BK_autoRecoveryDaemonEnabled
 - BK_lostBookieRecoveryDelay
 ```

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -293,7 +293,7 @@ func MakeBookieConfigMap(bk *v1alpha1.BookkeeperCluster) *corev1.ConfigMap {
 	}
 
 	if *bk.Spec.AutoRecovery {
-		configData["BK_AUTORECOVERY"] = "true"
+		configData["BK_autoRecoveryDaemonEnabled"] = "true"
 		// Wait one minute before starting autorecovery. This will give
 		// pods some time to come up after being updated or migrated
 		configData["BK_lostBookieRecoveryDelay"] = "60"

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -297,6 +297,8 @@ func MakeBookieConfigMap(bk *v1alpha1.BookkeeperCluster) *corev1.ConfigMap {
 		// Wait one minute before starting autorecovery. This will give
 		// pods some time to come up after being updated or migrated
 		configData["BK_lostBookieRecoveryDelay"] = "60"
+	} else {
+		configData["BK_autoRecoveryDaemonEnabled"] = "false"
 	}
 
 	for k, v := range bk.Spec.Options {

--- a/pkg/controller/bookkeepercluster/bookie_test.go
+++ b/pkg/controller/bookkeepercluster/bookie_test.go
@@ -58,8 +58,10 @@ var _ = Describe("Bookie", func() {
 						corev1.ResourceMemory: resource.MustParse("6Gi"),
 					},
 				}
+				boolFalse := false
 				bk.Spec = v1alpha1.BookkeeperClusterSpec{
-					Resources: customReq,
+					AutoRecovery: &boolFalse,
+					Resources:    customReq,
 					Options: map[string]string{
 						"journalDirectories": "/bk/journal/j0,/bk/journal/j1,/bk/journal/j2,/bk/journal/j3",
 						"ledgerDirectories":  "/bk/ledgers/l0,/bk/ledgers/l1,/bk/ledgers/l2,/bk/ledgers/l3",


### PR DESCRIPTION
### Change log description
In operator code, we were setting env variable `BK_AUTORECOVERY` if the autorecovery is set and in default cases. But the env variable used in `bk_server.conf` file is `autoRecoveryDaemonEnabled`.  Changed the env variable name from `BK_AUTORECOVERY`  to `BK_autoRecoveryDaemonEnabled`

### Purpose of the change

Fixes #12

### What the code does
Changed the env variable to `BK_autoRecoveryDaemonEnabled` and if autoRecovery is set to false in yaml file, update the env variable to false
### How to verify it
Verified that `bk_server.conf` file is updated correctly based on the value set. Checked with bookeeper version `6.1` and `7.0`