### PR TITLE
Issue 54: Fixing Bookkeeper cluster upgrade failure

### DIFF
--- a/charts/bookkeeper-operator/templates/clusterrole.yaml
+++ b/charts/bookkeeper-operator/templates/clusterrole.yaml
@@ -23,6 +23,8 @@ rules:
   - watch
   - list
   - create
+  - update
+  - delete
 - apiGroups:
   - admissionregistration.k8s.io
   resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -66,6 +66,8 @@ rules:
   - watch
   - list
   - create
+  - update
+  - delete
 - apiGroups:
   - admissionregistration.k8s.io
   resources:


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Due to lack of required clusterroles, bookkeeper upgrade was seen to fail when the bookeeper operator and bookkeeper cluster were deployed in different namespaces.

### Purpose of the change
Fixes #54 

### What the code does
Adds the required clusterroles to the bookkeeper operator service account.

### How to verify it
Bookkeeper Cluster is able to upgrade successfully even when the bookkeeper cluster and the bookkeeper operator are deployed in different namespaces.
