### PR TITLE
Changing default name of zookeeper service

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ helm install bookkeeper charts/bookkeeper --set zookeeperUri=[ZOOKEEPER_HOST] 
 
 where:
 
-- **[ZOOKEEPER_HOST]** is the Zookeeper service endpoint of your Zookeeper deployment (e.g. `zk-client:2181`). It expects the zookeeper service URL in the given format `<service-name>:<port-number>`
+- **[ZOOKEEPER_HOST]** is the Zookeeper service endpoint of your Zookeeper deployment (e.g. `zookeeper-client:2181`). It expects the zookeeper service URL in the given format `<service-name>:<port-number>`
 - **[CLUSTER_NAME]** is the name of the Pravega cluster (i.e. this field is optional and needs to be provided only if we expect this bookkeeper cluster to work with [Pravega](https://github.com/pravega/pravega)).
 
 Check out the [Bookkeeper Helm Chart](charts/bookkeeper) for more a complete list of installation parameters.

--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -43,7 +43,7 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 | `image.repository` | Image repository | `pravega/bookkeeper` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicas` | Number of bookkeeper replicas | `3` |
-| `zookeeperUri` | Zookeeper client service URI | `zk-client:2181` |
+| `zookeeperUri` | Zookeeper client service URI | `zookeeper-client:2181` |
 | `pravegaClusterName` | Name of the pravega cluster | `pravega` |
 | `autoRecovery`| Enable bookkeeper auto-recovery | `true` |
 | `resources.requests.cpu` | Requests for CPU resources | `500m` |

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -15,7 +15,7 @@ hooks:
   backoffLimit: 10
 
 replicas: 3
-zookeeperUri: zk-client:2181
+zookeeperUri: zookeeper-client:2181
 pravegaClusterName: pravega
 autoRecovery: true
 

--- a/deploy/config_map.yaml
+++ b/deploy/config_map.yaml
@@ -5,4 +5,4 @@ metadata:
 data:
   # Configuration values can be set as key-value properties
   PRAVEGA_CLUSTER_NAME: pravega
-  WAIT_FOR: zk-client:2181
+  WAIT_FOR: zookeeper-client:2181

--- a/deploy/crds/cr.yaml
+++ b/deploy/crds/cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "bookkeeper"
 spec:
   version: 0.7.0
-  zookeeperUri: zk-client:2181
+  zookeeperUri: zookeeper-client:2181
   image:
     repository: pravega/bookkeeper
     pullPolicy: IfNotPresent

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -90,7 +90,7 @@ spec:
 
 where:
 
-- `[ZOOKEEPER_HOST]` is the Zookeeper service endpoint of your Zookeeper deployment (e.g. `zk-client:2181`). It expects the zookeeper service URL in the given format `<service-name>:<port-number>`
+- `[ZOOKEEPER_HOST]` is the Zookeeper service endpoint of your Zookeeper deployment (e.g. `zookeeper-client:2181`). It expects the zookeeper service URL in the given format `<service-name>:<port-number>`
 
 Check out other sample CR files in the [`example`](../example) directory.
 

--- a/doc/upgrade-cluster.md
+++ b/doc/upgrade-cluster.md
@@ -16,25 +16,12 @@ Your Bookkeeper cluster should be in a healthy state. You can check your cluster
 ```
 $ kubectl get bk
 NAME        VERSION   DESIRED MEMBERS   READY MEMBERS   AGE
-bookkeeper  0.6.1        7                 7            11m
+bookkeeper  0.4.0        7                 7            11m
 ```
 
-## Upgrade Path Matrix
+## Valid Upgrade Paths
 
-| BASE VERSION | TARGET VERSION                          |
-| ------------ | ----------------                        |
-| 0.1.0        | 0.1.0                                   |
-| 0.2.0        | 0.2.0                                   |
-| 0.3.0        | 0.3.0, 0.3.1, 0.3.2                     |
-| 0.3.1        | 0.3.1, 0.3.2                            |
-| 0.3.2        | 0.3.2                                   |
-| 0.4.0        | 0.4.0                                   |
-| 0.5.0        | 0.5.0, 0.5.1, 0.6.0, 0.6.1, 0.7.0, 0.7.1|
-| 0.5.1        | 0.5.1, 0.6.0, 0.6.1, 0.7.0, 0.7.1       |
-| 0.6.0        | 0.6.0, 0.6.1, 0.7.0, 0.7.1              |
-| 0.6.1        | 0.6.1, 0.7.0, 0.7.1                     |
-| 0.7.0        | 0.7.0, 0.7.1                            |
-| 0.7.1        | 0.7.1                                   |
+To understand the valid upgrade paths for a pravega cluster, refer to the [version map](https://github.com/pravega/bookkeeper-operator/blob/master/deploy/version_map.yaml). The key indicates the base version of the cluster, and the value against each key indicates the list of valid versions this base version can be upgraded to.
 
 ## Trigger an upgrade
 

--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "bookkeeper"
 spec:
   version: 0.7.0
-  zookeeperUri: zk-client:2181
+  zookeeperUri: zookeeper-client:2181
 
   image:
     repository: pravega/bookkeeper

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -97,7 +97,7 @@ func (bk *BookkeeperCluster) WithDefaults() (changed bool) {
 type BookkeeperClusterSpec struct {
 	// ZookeeperUri specifies the hostname/IP address and port in the format
 	// "hostname:port".
-	// By default, the value "zk-client:2181" is used, that corresponds to the
+	// By default, the value "zookeeper-client:2181" is used, that corresponds to the
 	// default Zookeeper service created by the Pravega Zookkeeper operator
 	// available at: https://github.com/pravega/zookeeper-operator
 	ZookeeperUri string `json:"zookeeperUri"`

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// DefaultZookeeperUri is the default ZooKeeper URI in the form of "hostname:port"
-	DefaultZookeeperUri = "zk-client:2181"
+	DefaultZookeeperUri = "zookeeper-client:2181"
 
 	// DefaultPravegaVersion is the default tag used for for the Pravega
 	// Docker image

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types_test.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types_test.go
@@ -49,7 +49,7 @@ var _ = Describe("BookkeeperCluster Types Spec", func() {
 		})
 
 		It("should set zookeeper uri", func() {
-			Ω(bk.Spec.ZookeeperUri).Should(Equal("zk-client:2181"))
+			Ω(bk.Spec.ZookeeperUri).Should(Equal("zookeeper-client:2181"))
 		})
 
 		It("should set version to 0.7.0", func() {


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description

Modifies the default name of the zookeeper client service from `zk-client:2181` to `zookeeper-client:2181`which is the default value created by zookeeper.
