### PR TITLE
Issue 59: Fixing Bookie failure

### DIFF
--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -46,17 +46,17 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 | `zookeeperUri` | Zookeeper client service URI | `zookeeper-client:2181` |
 | `pravegaClusterName` | Name of the pravega cluster | `pravega` |
 | `autoRecovery`| Enable bookkeeper auto-recovery | `true` |
-| `resources.requests.cpu` | Requests for CPU resources | `500m` |
-| `resources.requests.memory` | Requests for memory resources | `1Gi` |
-| `resources.limits.cpu` | Limits for CPU resources | `1` |
-| `resources.limits.memory` | Limits for memory resources | `2Gi` |
+| `resources.requests.cpu` | Requests for CPU resources | `1000m` |
+| `resources.requests.memory` | Requests for memory resources | `4Gi` |
+| `resources.limits.cpu` | Limits for CPU resources | `2000m` |
+| `resources.limits.memory` | Limits for memory resources | `4Gi` |
 | `storage.ledger.className` | Storage class name for bookkeeper ledgers | `standard` |
 | `storage.ledger.volumeSize` | Requested size for bookkeeper ledger persistent volumes | `10Gi` |
 | `storage.journal.className` | Storage class name for bookkeeper journals | `standard` |
 | `storage.journal.volumeSize` | Requested size for bookkeeper journal persistent volumes | `10Gi` |
 | `storage.index.className` | Storage class name for bookkeeper index | `standard` |
 | `storage.index.volumeSize` | Requested size for bookkeeper index persistent volumes | `10Gi` |
-| `jvmOptions.memoryOpts` | Memory Options passed to the JVM for bookkeeper performance tuning | `[]` |
+| `jvmOptions.memoryOpts` | Memory Options passed to the JVM for bookkeeper performance tuning | `["-Xms1g", "-XX:MaxDirectMemorySize=2g"]` |
 | `jvmOptions.gcOpts` | Garbage Collector (GC) Options passed to the JVM for bookkeeper bookkeeper performance tuning | `[]` |
 | `jvmOptions.gcLoggingOpts` | GC Logging Options passed to the JVM for bookkeeper performance tuning | `[]` |
 | `jvmOptions.extraOpts` | Extra Options passed to the JVM for bookkeeper performance tuning | `[]` |

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -21,11 +21,11 @@ autoRecovery: true
 
 resources:
   requests:
-    cpu: 500m
-    memory: 1Gi
+    cpu: 1000m
+    memory: 4Gi
   limits:
-    cpu: 1
-    memory: 2Gi
+    cpu: 2000m
+    memory: 4Gi
 
 storage:
   ledger:
@@ -39,10 +39,26 @@ storage:
     volumeSize: 10Gi
 
 jvmOptions:
-  memoryOpts: []
+  memoryOpts: ["-Xms1g", "-XX:MaxDirectMemorySize=2g"]
   gcOpts: []
   gcLoggingOpts: []
   extraOpts: []
 
 options:
-  # useHostNameAsBookieID: "true"
+  useHostNameAsBookieID: "true"
+  ## We need an agressive data compaction policy in Bookkeeper, given that we may have IO heavy workloads that may fill up the disks.
+  ## For more information on these parameters, please see https://github.com/pravega/pravega/issues/4008.
+  minorCompactionThreshold: "0.4"
+  minorCompactionInterval: "1800"
+  majorCompactionThreshold: "0.8"
+  majorCompactionInterval: "43200"
+  isForceGCAllowWhenNoSpace: "true"
+  ## Use multiple journal and ledger directories to try exploiting more parallelism at the drive level.
+  journalDirectories: "/bk/journal/j0,/bk/journal/j1,/bk/journal/j2,/bk/journal/j3"
+  ledgerDirectories: "/bk/ledgers/l0,/bk/ledgers/l1,/bk/ledgers/l2,/bk/ledgers/l3"
+  ## We have validated that this simpler ledger type prevents Bookie restarts due to heap OOM compared to the default SortedLedgerStorage.
+  ## As we do not read from Bookkeeper (only during container recovery), this ledger type looks more efficient given our requirements.
+  ledgerStorageClass: "org.apache.bookkeeper.bookie.InterleavedLedgerStorage"
+  ## Only use these parameters if you want Bookkeeper to publish metrics (via Prometheus).
+  # enableStatistics: "true"
+  # statsProviderClass: "org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider"

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -12,8 +12,8 @@ package bookkeepercluster
 
 import (
 	"fmt"
-	"strings"
 	"strconv"
+	"strings"
 
 	"github.com/pravega/bookkeeper-operator/pkg/apis/bookkeeper/v1alpha1"
 	"github.com/pravega/bookkeeper-operator/pkg/util"
@@ -119,24 +119,24 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 	var ok bool
 
 	if _, ok = bk.Spec.Options["ledgerDirectories"]; ok {
-		ledgerDirs = strings.Split(bk.Spec.Options["ledgerDirectories"],",")
+		ledgerDirs = strings.Split(bk.Spec.Options["ledgerDirectories"], ",")
 	} else {
 		// default value if user did not set ledgerDirectories in options
-		ledgerDirs = append(ledgerDirs,"/bk/ledgers")
+		ledgerDirs = append(ledgerDirs, "/bk/ledgers")
 	}
 
 	if _, ok = bk.Spec.Options["journalDirectories"]; ok {
-		journalDirs = strings.Split(bk.Spec.Options["journalDirectories"],",")
+		journalDirs = strings.Split(bk.Spec.Options["journalDirectories"], ",")
 	} else {
 		// default value if user did not set journalDirectories in options
-		journalDirs = append(journalDirs,"/bk/journal")
+		journalDirs = append(journalDirs, "/bk/journal")
 	}
 
 	if _, ok = bk.Spec.Options["indexDirectories"]; ok {
-		indexDirs = strings.Split(bk.Spec.Options["indexDirectories"],",")
+		indexDirs = strings.Split(bk.Spec.Options["indexDirectories"], ",")
 	} else {
 		// default value if user did not set indexDirectories in options
-		indexDirs = append(indexDirs,"/bk/index")
+		indexDirs = append(indexDirs, "/bk/index")
 	}
 
 	podSpec := &corev1.PodSpec{
@@ -151,9 +151,9 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 						ContainerPort: 3181,
 					},
 				},
-				EnvFrom: environment,
-				VolumeMounts: createVolumeMount(ledgerDirs,journalDirs,indexDirs),
-				Resources: *bk.Spec.Resources,
+				EnvFrom:      environment,
+				VolumeMounts: createVolumeMount(ledgerDirs, journalDirs, indexDirs),
+				Resources:    *bk.Spec.Resources,
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{
@@ -201,32 +201,32 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 
 func createVolumeMount(ledgerDirs []string, journalDirs []string, indexDirs []string) []corev1.VolumeMount {
 	var volumeMounts []corev1.VolumeMount
-	for i,ledger := range ledgerDirs {
-		name := JournalDiskName+strconv.Itoa(i)
+	for i, ledger := range ledgerDirs {
+		name := JournalDiskName + strconv.Itoa(i)
 		v := corev1.VolumeMount{
 			Name:      LedgerDiskName,
 			MountPath: ledger,
 			SubPath:   name,
 		}
-		volumeMounts = append(volumeMounts,v)
+		volumeMounts = append(volumeMounts, v)
 	}
-	for i,journal := range journalDirs {
-		name := JournalDiskName+strconv.Itoa(i)
+	for i, journal := range journalDirs {
+		name := JournalDiskName + strconv.Itoa(i)
 		v := corev1.VolumeMount{
 			Name:      JournalDiskName,
 			MountPath: journal,
 			SubPath:   name,
 		}
-		volumeMounts = append(volumeMounts,v)
+		volumeMounts = append(volumeMounts, v)
 	}
-	for i,index := range indexDirs {
-		name := IndexDiskName+strconv.Itoa(i)
+	for i, index := range indexDirs {
+		name := IndexDiskName + strconv.Itoa(i)
 		v := corev1.VolumeMount{
 			Name:      IndexDiskName,
 			MountPath: index,
 			SubPath:   name,
 		}
-		volumeMounts = append(volumeMounts,v)
+		volumeMounts = append(volumeMounts, v)
 	}
 	return volumeMounts
 }

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -202,7 +202,7 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 func createVolumeMount(ledgerDirs []string, journalDirs []string, indexDirs []string) []corev1.VolumeMount {
 	var volumeMounts []corev1.VolumeMount
 	for i, ledger := range ledgerDirs {
-		name := JournalDiskName + strconv.Itoa(i)
+		name := LedgerDiskName + strconv.Itoa(i)
 		v := corev1.VolumeMount{
 			Name:      LedgerDiskName,
 			MountPath: ledger,

--- a/pkg/controller/bookkeepercluster/bookie_test.go
+++ b/pkg/controller/bookkeepercluster/bookie_test.go
@@ -67,6 +67,7 @@ var _ = Describe("Bookie", func() {
 					Options: map[string]string{
 						"journalDirectories": "/bk/journal/j0,/bk/journal/j1,/bk/journal/j2,/bk/journal/j3",
 						"ledgerDirectories":  "/bk/ledgers/l0,/bk/ledgers/l1,/bk/ledgers/l2,/bk/ledgers/l3",
+						"indexDirectories":   "/bk/index/i0,/bk/index/i1",
 					},
 				}
 				bk.WithDefaults()
@@ -110,6 +111,10 @@ var _ = Describe("Bookie", func() {
 					Ω(mountjournal1).Should(Equal("/bk/journal/j1"))
 					Ω(mountjournal2).Should(Equal("/bk/journal/j2"))
 					Ω(mountjournal3).Should(Equal("/bk/journal/j3"))
+					mountindex0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[8].MountPath
+					mountindex1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[9].MountPath
+					Ω(mountindex0).Should(Equal("/bk/index/i0"))
+					Ω(mountindex1).Should(Equal("/bk/index/i1"))
 				})
 			})
 		})

--- a/pkg/controller/bookkeepercluster/bookie_test.go
+++ b/pkg/controller/bookkeepercluster/bookie_test.go
@@ -94,10 +94,22 @@ var _ = Describe("Bookie", func() {
 
 				It("should have journal and ledgers dir set to the values given by user", func() {
 					sts := bookkeepercluster.MakeBookieStatefulSet(bk)
-					mountledger := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
-					Ω(mountledger).Should(Equal("/bk/ledgers/l0,/bk/ledgers/l1,/bk/ledgers/l2,/bk/ledgers/l3"))
-					mountjournal := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath
-					Ω(mountjournal).Should(Equal("/bk/journal/j0,/bk/journal/j1,/bk/journal/j2,/bk/journal/j3"))
+					mountledger0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
+					mountledger1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath
+					mountledger2 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
+					mountledger3 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[3].MountPath
+					Ω(mountledger0).Should(Equal("/bk/ledgers/l0"))
+					Ω(mountledger1).Should(Equal("/bk/ledgers/l1"))
+					Ω(mountledger2).Should(Equal("/bk/ledgers/l2"))
+					Ω(mountledger3).Should(Equal("/bk/ledgers/l3"))
+					mountjournal0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[4].MountPath
+					mountjournal1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[5].MountPath
+					mountjournal2 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[6].MountPath
+					mountjournal3 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[7].MountPath
+					Ω(mountjournal0).Should(Equal("/bk/journal/j0"))
+					Ω(mountjournal1).Should(Equal("/bk/journal/j1"))
+					Ω(mountjournal2).Should(Equal("/bk/journal/j2"))
+					Ω(mountjournal3).Should(Equal("/bk/journal/j3"))
 				})
 			})
 		})
@@ -132,6 +144,8 @@ var _ = Describe("Bookie", func() {
 					Ω(mountledger).Should(Equal("/bk/ledgers"))
 					mountjournal := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath
 					Ω(mountjournal).Should(Equal("/bk/journal"))
+					indexjournal := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
+					Ω(indexjournal).Should(Equal("/bk/index"))
 				})
 			})
 		})


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
After changes done by [this PR](https://github.com/pravega/bookkeeper-operator/pull/44), specifying LedgerDirectories for bookkeeper as a comma-separated list of directories `(ledgerDirectories: "/bk/ledgers/l0,/bk/ledgers/l1,/bk/ledgers/l2,/bk/ledgers/l3")`, creates following directory structure is inside the bookkeeper pods
```
$ ls /bk/ledgers/
l0  l0,  l1  l2  l3

$ ls /bk/ledgers/l0,/bk/ledgers/l1,/bk/ledgers/l2,/bk/ledgers/l3/
lost+found
```
Hence the ledger and journal directories are not getting mounted in the expected manner.

### Purpose of the change
Fixes #59 

### What the code does
Splits the compound string provided to specify comma separated list of `ledgerDirectories` or `journalDirectories` and accordingly creates the mount paths.

### How to verify it
After applying the fix, the comma separated list of directories is correctly mounted as seen below
```
$ ls /bk/ledgers/
l0  l1  l2  l3
```
