### PR TITLE
Issue 65: Allowing non-valid image versions to be used in non-production environments

### DIFF
--- a/charts/bookkeeper-operator/README.md
+++ b/charts/bookkeeper-operator/README.md
@@ -44,5 +44,6 @@ The following table lists the configurable parameters of the Bookkeeper operator
 | `rbac.create` | Create RBAC resources | `true` |
 | `serviceAccount.create` | Create service account | `true` |
 | `serviceAccount.name` | Name for the service account | `bookkeeper-operator` |
-| `testmode` | Enable test mode | `false` |
+| `testmode.enabled` | Enable test mode | `false` |
+| `testmode.version` | Major version number of the alternate bookkeeper image we want the operator to deploy, if test mode is enabled | `""` |
 | `watchNamespace` | Namespaces to be watched  | `""` |

--- a/charts/bookkeeper-operator/templates/operator.yaml
+++ b/charts/bookkeeper-operator/templates/operator.yaml
@@ -26,7 +26,7 @@ spec:
           name: metrics
         command:
         - bookkeeper-operator
-        {{- if .Values.testmode }}
+        {{- if .Values.testmode.enabled }}
         args: [-test]
         {{- end }}
         env:

--- a/charts/bookkeeper-operator/templates/version_map.yaml
+++ b/charts/bookkeeper-operator/templates/version_map.yaml
@@ -20,3 +20,6 @@ data:
         0.6.2:0.6.2,0.7.0,0.7.1
         0.7.0:0.7.0,0.7.1
         0.7.1:0.7.1
+        {{- if and .Values.testmode.enabled .Values.testmode.version }}
+        {{ .Values.testmode.version }}:{{ .Values.testmode.version }}
+        {{- end }}

--- a/charts/bookkeeper-operator/values.yaml
+++ b/charts/bookkeeper-operator/values.yaml
@@ -20,8 +20,12 @@ serviceAccount:
 crd:
   create: true
 
-## Whether to enable test mode.
-testmode: false
+testmode:
+  enabled: false
+  ## version of pravega that you wish to deploy
+  ## mention the major version number
+  ## eg. enter 0.8.0 if u wish to deploy version 0.8.0-2500.efe501a
+  version: ""
 
 ## Specifies which namespace the Operator should watch over.
 ## An empty string means all namespaces.


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
The bookkeeper-operator should provide users a way to deploy a non-valid image version in non-production environments, since currently there doesn't seem to be any way to use the bookkeeper-operator charts (without modifying them) to deploy bookkeeper versions that are not already part of the version map.

### Purpose of the change
Fixes #65 

### What the code does
When test-mode is enabled in the bookkeeper-operator, the major version that is provided by the user within `testmode.version` is added to the bk-supported-versions configmap that is created by the operator.

### How to verify it
Provide the image version (major version number) that you wish to deploy which is not part of `version_map.yaml` by first enabling test-mode in the bookkeeper-operator `values.yaml` file in the following way
```
testmode:
  enabled: true
  version: "0.8.2"
```
This adds `0.8.2` to the configmap that is created by the operator
```
$ kubectl describe cm bk-supported-versions-map
Name:         bk-supported-versions-map
Namespace:    default
Labels:       app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=bookkeeper-operator
              app.kubernetes.io/version=0.1.2
              helm.sh/chart=bookkeeper-operator-0.1.2
Annotations:  meta.helm.sh/release-name: bko
              meta.helm.sh/release-namespace: default

Data
====
keys:
----
0.1.0:0.1.0
0.2.0:0.2.0
0.3.0:0.3.0,0.3.1,0.3.2
0.3.1:0.3.1,0.3.2
0.3.2:0.3.2
0.4.0:0.4.0
0.5.0:0.5.0,0.5.1,0.6.0,0.6.1,0.6.2,0.7.0,0.7.1
0.5.1:0.5.1,0.6.0,0.6.1,0.6.2,0.7.0,0.7.1
0.6.0:0.6.0,0.6.1,0.6.2,0.7.0,0.7.1
0.6.1:0.6.1,0.6.2,0.7.0,0.7.1
0.6.2:0.6.2,0.7.0,0.7.1
0.7.0:0.7.0,0.7.1
0.7.1:0.7.1
0.8.2:0.8.2
```
This way, bookkeeper-operator will be able to successfully deploy bookkeeper version `0.8.2-xxxx.xxxx`
