### PR TITLE
Issue 73: Provide support for configuring block owner deletion  for PVC's

### DIFF
--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -32,7 +32,7 @@ $ helm uninstall my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
-> Note: If you are setting blockOwnerDeletion to false during installtion, PVC's won't be removed automatically while uninstalling bookkeepercluster. PVCs has to be deleted manually.
+> Note: If you are setting blockOwnerDeletion to false during installtion, PVC's won't be removed automatically while uninstalling bookkeepercluster. PVCs have to be deleted manually.
 ## Configuration
 
 The following table lists the configurable parameters of the Bookkeeper chart and their default values.

--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -32,7 +32,7 @@ $ helm uninstall my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
-
+> Note: If you are setting blockOwnerDeletion to false during installtion, PVC's won't be removed automatically while uninstalling bookkeepercluster. Pvcs has to be deleted manually.
 ## Configuration
 
 The following table lists the configurable parameters of the Bookkeeper chart and their default values.
@@ -46,6 +46,7 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 | `zookeeperUri` | Zookeeper client service URI | `zookeeper-client:2181` |
 | `pravegaClusterName` | Name of the pravega cluster | `pravega` |
 | `autoRecovery`| Enable bookkeeper auto-recovery | `true` |
+| `blockOwnerDeletion`| Enable blockOwnerDeletion | `true` |
 | `probes` | Timeout configuration of the readiness and liveness probes for the bookkeeper pods | `{}` |
 | `resources.requests.cpu` | Requests for CPU resources | `1000m` |
 | `resources.requests.memory` | Requests for memory resources | `4Gi` |

--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -32,7 +32,7 @@ $ helm uninstall my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
-> Note: If you are setting blockOwnerDeletion to false during installtion, PVC's won't be removed automatically while uninstalling bookkeepercluster. Pvcs has to be deleted manually.
+> Note: If you are setting blockOwnerDeletion to false during installtion, PVC's won't be removed automatically while uninstalling bookkeepercluster. PVCs has to be deleted manually.
 ## Configuration
 
 The following table lists the configurable parameters of the Bookkeeper chart and their default values.

--- a/charts/bookkeeper/templates/bookkeeper.yaml
+++ b/charts/bookkeeper/templates/bookkeeper.yaml
@@ -14,7 +14,7 @@ spec:
   zookeeperUri: {{ .Values.zookeeperUri }}
   envVars: {{ template "bookkeeper.fullname" . }}-configmap
   autoRecovery: {{ .Values.autoRecovery }}
-  blockOwnerDeletion: {{ .Values.blockOwnerDeletion }}
+  blockOwnerDeletion: {{ default true .Values.blockOwnerDeletion }}
   {{- if .Values.probes }}
   probes:
     {{- if .Values.probes.readiness }}

--- a/charts/bookkeeper/templates/bookkeeper.yaml
+++ b/charts/bookkeeper/templates/bookkeeper.yaml
@@ -14,6 +14,7 @@ spec:
   zookeeperUri: {{ .Values.zookeeperUri }}
   envVars: {{ template "bookkeeper.fullname" . }}-configmap
   autoRecovery: {{ .Values.autoRecovery }}
+  blockOwnerDeletion: {{ .Values.blockOwnerDeletion }}
   {{- if .Values.probes }}
   probes:
     {{- if .Values.probes.readiness }}

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -18,6 +18,7 @@ replicas: 3
 zookeeperUri: zookeeper-client:2181
 pravegaClusterName: pravega
 autoRecovery: true
+blockOwnerDeletion: true
 
 probes: {}
   # readiness:

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -12,7 +12,7 @@ package v1alpha1
 
 import (
 	"github.com/pravega/bookkeeper-operator/pkg/controller/config"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -191,6 +191,11 @@ type BookkeeperClusterSpec struct {
 	//
 	// If version is not set, default is "0.4.0".
 	Version string `json:"version"`
+	// If true, AND if the owner has the "foregroundDeletion" finalizer, then
+	// the owner cannot be deleted from the key-value store until this
+	// reference is removed.
+	// Defaults to true
+	BlockOwnerDeletion *bool `json:"blockOwnerDeletion,omitempty"`
 }
 
 // BookkeeperImageSpec defines the fields needed for a BookKeeper Docker image
@@ -411,6 +416,13 @@ func (s *BookkeeperClusterSpec) withDefaults() (changed bool) {
 		s.Version = DefaultBookkeeperVersion
 		changed = true
 	}
+
+	if s.BlockOwnerDeletion == nil {
+		changed = true
+		boolTrue := true
+		s.BlockOwnerDeletion = &boolTrue
+	}
+
 	return changed
 }
 

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
@@ -192,6 +192,12 @@ func (r *ReconcileBookkeeperCluster) deployBookie(p *bookkeeperv1alpha1.Bookkeep
 	controllerutil.SetControllerReference(p, statefulSet, r.scheme)
 	for i := range statefulSet.Spec.VolumeClaimTemplates {
 		controllerutil.SetControllerReference(p, &statefulSet.Spec.VolumeClaimTemplates[i], r.scheme)
+		if *p.Spec.BlockOwnerDeletion == false {
+			refs := statefulSet.Spec.VolumeClaimTemplates[i].OwnerReferences
+			for i := range refs {
+				refs[i].BlockOwnerDeletion = p.Spec.BlockOwnerDeletion
+			}
+		}
 	}
 	err = r.client.Create(context.TODO(), statefulSet)
 	if err != nil && !errors.IsAlreadyExists(err) {

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller_test.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller_test.go
@@ -125,8 +125,11 @@ var _ = Describe("BookkeeperCluster Controller", func() {
 			Context("syncBookieSize", func() {
 				var (
 					err1 error
+					flag bool
 				)
 				BeforeEach(func() {
+					flag = false
+					b.Spec.BlockOwnerDeletion = &flag
 					b.WithDefaults()
 					//to ensure the client get for BookKeepercluster fails
 					err = r.syncBookieSize(b)


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description

Addd a new field in spec `BlockOwnerDeletion`   If this filed is set to false, we are setting blockownerDeletion in Ownerreference to false for all the bookkeeper persistent volume claims.
### Purpose of the change

 Fixes #73 

### What the code does

Added a new field blockownerDeletion that can be configured by user. If it is set to false blockowner deletion is set to false for Persistent volume claims.

### How to verify it

Verified that if block owner deletion is set to false , Pvcs are coming up fine in OPenshift environment
