### PR TITLE
Issue 82: Handling Bookkeeper Upgrade

### DIFF
--- a/charts/bookkeeper/templates/bookkeeper.yaml
+++ b/charts/bookkeeper/templates/bookkeeper.yaml
@@ -8,8 +8,9 @@ metadata:
 spec:
   replicas: {{ .Values.replicas }}
   image:
-    repository: {{ .Values.image.repository }}
-    pullPolicy: {{ .Values.image.pullPolicy }}
+    imageSpec:
+      repository: {{ .Values.image.repository }}
+      pullPolicy: {{ .Values.image.pullPolicy }}
   version: {{ .Values.version }}
   zookeeperUri: {{ .Values.zookeeperUri }}
   envVars: {{ template "bookkeeper.fullname" . }}-configmap

--- a/deploy/crds/cr.yaml
+++ b/deploy/crds/cr.yaml
@@ -6,8 +6,9 @@ spec:
   version: 0.7.0
   zookeeperUri: zookeeper-client:2181
   image:
-    repository: pravega/bookkeeper
-    pullPolicy: IfNotPresent
+    imageSpec:
+      repository: pravega/bookkeeper
+      pullPolicy: IfNotPresent
   replicas: 3
   envVars: bookkeeper-configmap
   autoRecovery: true

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -97,8 +97,9 @@ spec:
   envVars: bookkeeper-configmap
   replicas: 3
   image:
-    repository: pravega/bookkeeper
-    pullPolicy: IfNotPresent
+    imageSpec:
+      repository: pravega/bookkeeper
+      pullPolicy: IfNotPresent
 ```
 
 where:

--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -7,7 +7,9 @@ spec:
   zookeeperUri: zookeeper-client:2181
 
   image:
-    repository: pravega/bookkeeper
+    imageSpec:
+      repository: pravega/bookkeeper
+      pullPolicy: IfNotPresent
 
   replicas: 3
 

--- a/pkg/controller/bookkeepercluster/upgrade.go
+++ b/pkg/controller/bookkeepercluster/upgrade.go
@@ -316,6 +316,10 @@ func (r *ReconcileBookkeeperCluster) getOneOutdatedPod(sts *appsv1.StatefulSet, 
 		return nil, err
 	}
 
+	sort.SliceStable(podList.Items, func(i int, j int) bool {
+		return podList.Items[i].Name < podList.Items[j].Name
+	})
+
 	for _, podItem := range podList.Items {
 		if util.GetPodVersion(&podItem) == version {
 			continue

--- a/pkg/controller/bookkeepercluster/upgrade.go
+++ b/pkg/controller/bookkeepercluster/upgrade.go
@@ -13,6 +13,7 @@ package bookkeepercluster
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	bookkeeperv1alpha1 "github.com/pravega/bookkeeper-operator/pkg/apis/bookkeeper/v1alpha1"


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
With the upgrade of controller runtime, the updated `client.List` method does not return the list of pods in a sorted order, which was breaking the sequential one-pod-at-a-time upgrade logic that had been implemented in the operator.

### Purpose of the change
Fixes #82 

### What the code does
The list of pods returned by the `client.List` method is sorted by name before doing any further processing, to maintain consistency with the previous logic.

### How to verify it
Upgrade the bookkeeper cluster from one version to another and ensure that not more than one pod is ugraded at any given time.
