### PR TITLE
Adding changes to modify bk configmap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,7 @@ jobs:
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default create -f /root/bookkeeper-operator/deploy/certificate.yaml"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default create -f /root/bookkeeper-operator/deploy/webhook.yaml"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default create -f /root/bookkeeper-operator/deploy/version_map.yaml"
-        ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default apply secret docker-registry regcred --docker-server=https://index.docker.io/v1/ --docker-username=testbkop --docker-password=08d50da6-61bd-4953-a2ce-7d7a0e3835bc --docker-email=testbkop@gmail.com"
+        ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default create secret docker-registry regcred --docker-server=https://index.docker.io/v1/ --docker-username=testbkop --docker-password=08d50da6-61bd-4953-a2ce-7d7a0e3835bc --docker-email=testbkop@gmail.com"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/$OPERATOR_SDK_VERSION/operator-sdk-$OPERATOR_SDK_VERSION-x86_64-linux-gnu && chmod +x operator-sdk && sudo mv operator-sdk /usr/local/bin/"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer);source /root/.gvm/scripts/gvm;gvm install go1.13.8 --binary;gvm use go1.13.8 --default"
     - name: Running e2e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,8 @@ jobs:
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default create -f /root/bookkeeper-operator/deploy/crds/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default create -f /root/bookkeeper-operator/deploy/certificate.yaml"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default create -f /root/bookkeeper-operator/deploy/webhook.yaml"
-        ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default  create -f /root/bookkeeper-operator/deploy/version_map.yaml"
+        ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default create -f /root/bookkeeper-operator/deploy/version_map.yaml"
+        ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default apply secret docker-registry regcred --docker-server=https://index.docker.io/v1/ --docker-username=testbkop --docker-password=08d50da6-61bd-4953-a2ce-7d7a0e3835bc --docker-email=testbkop@gmail.com"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/$OPERATOR_SDK_VERSION/operator-sdk-$OPERATOR_SDK_VERSION-x86_64-linux-gnu && chmod +x operator-sdk && sudo mv operator-sdk /usr/local/bin/"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer);source /root/.gvm/scripts/gvm;gvm install go1.13.8 --binary;gvm use go1.13.8 --default"
     - name: Running e2e

--- a/charts/bookkeeper-operator/templates/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
+++ b/charts/bookkeeper-operator/templates/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
@@ -116,6 +116,11 @@ spec:
                     type: string
                   type: array
               type: object
+            maxUnavailableBookkeeperReplicas:
+              description: MaxUnavailableBookkeeperReplicas defines the MaxUnavailable
+                Bookkeeper Replicas Default is 1.
+              format: int32
+              type: integer
             options:
               additionalProperties:
                 type: string

--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -58,6 +58,7 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 | `image.repository` | Image repository | `pravega/bookkeeper` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicas` | Number of bookkeeper replicas | `3` |
+| `maxUnavailableBookkeeperReplicas` | Number of maxUnavailableBookkeeperReplicas for bookkeeper PDB | `1` |
 | `zookeeperUri` | Zookeeper client service URI | `zookeeper-client:2181` |
 | `pravegaClusterName` | Name of the pravega cluster | `pravega` |
 | `autoRecovery`| Enable bookkeeper auto-recovery | `true` |

--- a/charts/bookkeeper/templates/bookkeeper.yaml
+++ b/charts/bookkeeper/templates/bookkeeper.yaml
@@ -7,6 +7,7 @@ metadata:
 {{ include "bookkeeper.commonLabels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
+  maxUnavailableBookkeeperReplicas: {{ .Values.maxUnavailableBookkeeperReplicas }}
   image:
     imageSpec:
       repository: {{ .Values.image.repository }}

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -15,6 +15,7 @@ hooks:
   backoffLimit: 10
 
 replicas: 3
+maxUnavailableBookkeeperReplicas: 1
 zookeeperUri: zookeeper-client:2181
 pravegaClusterName: pravega
 autoRecovery: true

--- a/deploy/crds/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
+++ b/deploy/crds/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
@@ -115,6 +115,11 @@ spec:
                     type: string
                   type: array
               type: object
+            maxUnavailableBookkeeperReplicas:
+              description: MaxUnavailableBookkeeperReplicas defines the MaxUnavailable
+                Bookkeeper Replicas Default is 1.
+              format: int32
+              type: integer              
             options:
               additionalProperties:
                 type: string

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -186,6 +186,12 @@ type BookkeeperClusterSpec struct {
 	// +optional
 	Replicas int32 `json:"replicas"`
 
+	// MaxUnavailableBookkeeperReplicas defines the
+	// MaxUnavailable Bookkeeper Replicas
+	// Default is 1.
+	// +optional
+	MaxUnavailableBookkeeperReplicas int32 `json:"maxUnavailableBookkeeperReplicas"`
+
 	// Storage configures the storage for BookKeeper
 	// +optional
 	Storage *BookkeeperStorageSpec `json:"storage"`
@@ -422,6 +428,11 @@ func (s *BookkeeperClusterSpec) withDefaults() (changed bool) {
 	if !config.TestMode && s.Replicas < MinimumBookkeeperReplicas {
 		changed = true
 		s.Replicas = MinimumBookkeeperReplicas
+	}
+
+	if !config.TestMode && s.MaxUnavailableBookkeeperReplicas < 1 {
+		changed = true
+		s.MaxUnavailableBookkeeperReplicas = 1
 	}
 
 	if s.Storage == nil {

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -377,7 +377,7 @@ func MakeBookieConfigMap(bk *v1alpha1.BookkeeperCluster) *corev1.ConfigMap {
 }
 
 func MakeBookiePodDisruptionBudget(bk *v1alpha1.BookkeeperCluster) *policyv1beta1.PodDisruptionBudget {
-	maxUnavailable := intstr.FromInt(1)
+	maxUnavailable := intstr.FromInt(int(bk.Spec.MaxUnavailableBookkeeperReplicas))
 	return &policyv1beta1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
@@ -362,8 +362,15 @@ func (r *ReconcileBookkeeperCluster) reconcilePdb(bk *bookkeeperv1alpha1.Bookkee
 	pdb := MakeBookiePodDisruptionBudget(bk)
 	controllerutil.SetControllerReference(bk, pdb, r.scheme)
 	err = r.client.Create(context.TODO(), pdb)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return err
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			err = r.client.Update(context.TODO(), pdb)
+			if err != nil {
+				return fmt.Errorf("failed to update pdb (%s): %v", pdb.Name, err)
+			}
+		} else {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
@@ -371,10 +371,10 @@ func (r *ReconcileBookkeeperCluster) reconcilePdb(bk *bookkeeperv1alpha1.Bookkee
 
 	currentPdb := &policyv1beta1.PodDisruptionBudget{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: util.PdbNameForBookie(bk.Name), Namespace: bk.Namespace}, currentPdb)
-	if err!= nil{
+	if err != nil {
 		return err
 	}
-	return r.updatePdb(currentPdb,pdb)
+	return r.updatePdb(currentPdb, pdb)
 }
 
 func (r *ReconcileBookkeeperCluster) updatePdb(currentPdb *policyv1beta1.PodDisruptionBudget, newPdb *policyv1beta1.PodDisruptionBudget) (err error) {
@@ -388,8 +388,6 @@ func (r *ReconcileBookkeeperCluster) updatePdb(currentPdb *policyv1beta1.PodDisr
 	}
 	return nil
 }
-
-
 
 func (r *ReconcileBookkeeperCluster) reconcileService(bk *bookkeeperv1alpha1.BookkeeperCluster) error {
 	headlessService := MakeBookieHeadlessService(bk)


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>

### Change log description
This pr helps prevent segmentstore and controller pods from evicting if number of bookkeeper pods are greater than number of nodes. By making the PDB Configurable.

### Purpose of the change
Fixes #103 

### What the code does
Added **maxUnavailableBookkeeperReplicas** field which will be used to configure the Bookkeeper pdb.
 
### How to verify it
Modify the above field and check inside the bookkeeper PDB's it should have the modified values.
