### PR TITLE
Issue 105: Adding support for ledger/journal subpath modification

### DIFF
--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -71,6 +71,9 @@ options:
   ## Use multiple journal and ledger directories to try exploiting more parallelism at the drive level.
   journalDirectories: "/bk/journal/j0,/bk/journal/j1,/bk/journal/j2,/bk/journal/j3"
   ledgerDirectories: "/bk/ledgers/l0,/bk/ledgers/l1,/bk/ledgers/l2,/bk/ledgers/l3"
+  ## Use journal and ledger subpath if you wish to override the default subpath name used
+  # journalSubPath: ""
+  # ledgerSubPath: ""
   ## We have validated that this simpler ledger type prevents Bookie restarts due to heap OOM compared to the default SortedLedgerStorage.
   ## As we do not read from Bookkeeper (only during container recovery), this ledger type looks more efficient given our requirements.
   ledgerStorageClass: "org.apache.bookkeeper.bookie.InterleavedLedgerStorage"


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Provides user with the option to override the default the subpath name used by the operator while creating the ledger/journal/index directories. This is needed to allow operator upgrades from version 0.1.1 to 0.1.3 in the case where multiple ledger/journal/index directories have been specified with operator 0.1.1

### Purpose of the change
Fixes #105 

### What the code does
In case the user specifies the ledgerSubPath and journalSubPath within the bookkeeper options, the operator will use this name suffixed with the appropriate index value as the subpath name to override the default subpath name used by the operator.

### How to verify it
Specify the ledger and journal subpath within options in the following manner while upgrading from bookkeeper operator 0.1.1 to 0.1.3 when multiple journal and ledger directories have been mentioned with the 0.1.1 operator version
```
options:
  journalDirectories: "/bk/journal/j0,/bk/journal/j1,/bk/journal/j2,/bk/journal/j3"
  ledgerDirectories: "/bk/ledgers/l0,/bk/ledgers/l1,/bk/ledgers/l2,/bk/ledgers/l3"
  journalSubPath: "j"
  ledgerSubPath: "l"
```
In this case the volume mounts are created as follows :
```
Mounts:
  /bk/index from index (rw)
  /bk/journal/j0 from journal (rw,path="j0")
  /bk/journal/j1 from journal (rw,path="j1")
  /bk/journal/j2 from journal (rw,path="j2")
  /bk/journal/j3 from journal (rw,path="j3")
  /bk/ledgers/l0 from ledger (rw,path="l0")
  /bk/ledgers/l1 from ledger (rw,path="l1")
  /bk/ledgers/l2 from ledger (rw,path="l2")
  /bk/ledgers/l3 from ledger (rw,path="l3")
```
In all other cases, we can skip mentioning these options `journalSubPath, ledgerSubPath` within the values.yaml, in which case the default value for the journalSubPath (i.e. `JournalDiskName`) and ledgerSubPath (i.e. `LedgerDiskName`) will be used. The volume mounts created in this case are as follows :
```
Mounts:
  /bk/index from index (rw)
  /bk/journal/j0 from journal (rw,path="journal0")
  /bk/journal/j1 from journal (rw,path="journal1")
  /bk/journal/j2 from journal (rw,path="journal2")
  /bk/journal/j3 from journal (rw,path="journal3")
  /bk/ledgers/l0 from ledger (rw,path="ledger0")
  /bk/ledgers/l1 from ledger (rw,path="ledger1")
  /bk/ledgers/l2 from ledger (rw,path="ledger2")
  /bk/ledgers/l3 from ledger (rw,path="ledger3")
```