### PR TITLE
Issue-109: Added changes for Avoiding 2 Restarts when Both Version and cm changes are done at the same time

### DIFF
--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
@@ -342,7 +342,6 @@ func (r *ReconcileBookkeeperCluster) reconcileConfigMap(bk *bookkeeperv1alpha1.B
 			}
 		}
 	} else {
-
 		currentConfigMap := &corev1.ConfigMap{}
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: util.ConfigMapNameForBookie(bk.Name), Namespace: bk.Namespace}, currentConfigMap)
 		eq := util.CompareConfigMap(currentConfigMap, configMap)

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
@@ -353,7 +353,6 @@ func (r *ReconcileBookkeeperCluster) reconcileConfigMap(bk *bookkeeperv1alpha1.B
 			}
 			//restarting sts pods
 			if !r.checkVersionUpgradeTriggered(bk) {
-				log.Printf("prabhaker why am I here")
 				err = r.restartStsPod(bk)
 				if err != nil {
 					return err
@@ -367,7 +366,6 @@ func (r *ReconcileBookkeeperCluster) reconcileConfigMap(bk *bookkeeperv1alpha1.B
 func (r *ReconcileBookkeeperCluster) checkVersionUpgradeTriggered(bk *bookkeeperv1alpha1.BookkeeperCluster) bool {
 	currentBookkeeperCluster := &bookkeeperv1alpha1.BookkeeperCluster{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: bk.Name, Namespace: bk.Namespace}, currentBookkeeperCluster)
-	log.Printf("anisha = %v and  %v", currentBookkeeperCluster.Status.CurrentVersion, bk.Spec.Version)
 	if err == nil && currentBookkeeperCluster.Status.CurrentVersion != bk.Spec.Version {
 		return true
 	}

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
@@ -352,13 +352,26 @@ func (r *ReconcileBookkeeperCluster) reconcileConfigMap(bk *bookkeeperv1alpha1.B
 				return err
 			}
 			//restarting sts pods
-			err = r.restartStsPod(bk)
-			if err != nil {
-				return err
+			if !r.checkVersionUpgradeTriggered(bk) {
+				log.Printf("prabhaker why am I here")
+				err = r.restartStsPod(bk)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
 	return nil
+}
+
+func (r *ReconcileBookkeeperCluster) checkVersionUpgradeTriggered(bk *bookkeeperv1alpha1.BookkeeperCluster) bool {
+	currentBookkeeperCluster := &bookkeeperv1alpha1.BookkeeperCluster{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: bk.Name, Namespace: bk.Namespace}, currentBookkeeperCluster)
+	log.Printf("anisha = %v and  %v", currentBookkeeperCluster.Status.CurrentVersion, bk.Spec.Version)
+	if err == nil && currentBookkeeperCluster.Status.CurrentVersion != bk.Spec.Version {
+		return true
+	}
+	return false
 }
 func (r *ReconcileBookkeeperCluster) reconcilePdb(bk *bookkeeperv1alpha1.BookkeeperCluster) (err error) {
 

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller_test.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller_test.go
@@ -163,6 +163,24 @@ var _ = Describe("BookkeeperCluster Controller", func() {
 					Ω(str1).To(Equal("3"))
 				})
 			})
+			Context("checking checkVersionUpgradeTriggered function", func() {
+				var (
+					ans1, ans2 bool
+				)
+				BeforeEach(func() {
+					ans1 = r.checkVersionUpgradeTriggered(b)
+					b.Spec.Version = "0.8.0"
+					ans2 = r.checkVersionUpgradeTriggered(b)
+				})
+				It("ans1 should be false", func() {
+					Ω(ans1).To(Equal(false))
+				})
+				It("ans2 should be true", func() {
+					Ω(ans2).To(Equal(true))
+				})
+
+			})
+
 			Context("syncBookieSize", func() {
 				var (
 					err1 error


### PR DESCRIPTION
… done at the same time

Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>

### Change log description
Added changes for Avoiding 2 Restarts when Both Version and cm changes are done at the same time. This makes the upgrade process fast and we don't get error messages due to race condition.

### Purpose of the change
Fixes #109 

### What the code does
Code checks for any change in the version of the bk cluster when there are changes in cm and if there is change in the version
then we skip restart of pods and only upgrade the cm

### How to verify it
Install bk cluster then upgrade the cluster along with changing some field in the option we should only see one restart of all k pods and the upgrade should complete.