### PR TITLE
Allow extra volume mounts to be configured #115

### DIFF
--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -84,3 +84,4 @@ options:
   ## Only use these parameters if you want Bookkeeper to publish metrics (via Prometheus).
   # enableStatistics: "true"
   # statsProviderClass: "org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider"
+  # extraVolumeMounts: "foo=/tmp/foo,bar=/tmp/bar"


### PR DESCRIPTION
### Change log description

* introduces the `extraVolumeMounts` option as multiple key-value pairs, separated by commas and each consisting of a `<name>=<path>` tuple.
* parses the `extraVolumeMounts` value.
* adds the extracted values to the `volumes` list and containers' `volumeMounts` list.

### Purpose of the change

Implements #115 

Bookkeeper operator should allow to specify "extra" volumes to be mounted into a bookie container. Such volumes may be used to share data among the hosts or containers.

### What the code does

The code implements a new bookie option: `extraVolumeMounts`.
To use "extra" volumes in the bookie pods, specify the `extraVolumeMounts` option in the Bookkeeper options.
The `extraVolumeMounts` option consists of multiple key-value pairs, separated by commas and each consisting of a `<name>=<path>` tuple:
- `<name>` is a volume name, the file or directory.
- `<path>` is where the volume is mounted in the container.

For example, `extraVolumeMounts: "foo=/tmp/foo,bar=/tmp/bar"`


### How to verify it

1. Create a new directory on the hosts. For example, `mkdir /tmp/bar`
2. Add the `extraVolumeMounts` option into the Bookkeeper options: `extraVolumeMounts`: "foo=/tmp/foo,bar=/tmp/bar".
3. When the cluster is deployed, make sure that the directory mounted to all the bookie containers.