### PR TITLE
Issue 83: Add configmap volumeMount to bookie container

### DIFF
--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -86,4 +86,5 @@ options:
   # enableStatistics: "true"
   # statsProviderClass: "org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider"
   # hostPathVolumeMounts: "foo=/tmp/foo,bar=/tmp/bar"
-  # emptyDirVolumeMounts: "baz=/tmp/baz,quux=/tmp/quux"
+  # emptyDirVolumeMounts: "heap-dump=/tmp/dumpfile/heap,log=/opt/bookkeeper/logs"
+  # configMapVolumeMounts: "bk-log4j:log4j.properties=/opt/bookkeeper/conf/log4j.properties"

--- a/pkg/controller/bookkeepercluster/bookie_test.go
+++ b/pkg/controller/bookkeepercluster/bookie_test.go
@@ -81,11 +81,12 @@ var _ = Describe("Bookie", func() {
 						},
 					},
 					Options: map[string]string{
-						"journalDirectories":   "/bk/journal/j0,/bk/journal/j1,/bk/journal/j2,/bk/journal/j3",
-						"ledgerDirectories":    "/bk/ledgers/l0,/bk/ledgers/l1,/bk/ledgers/l2,/bk/ledgers/l3",
-						"indexDirectories":     "/bk/index/i0,/bk/index/i1",
-						"hostPathVolumeMounts": "foo=/tmp/foo,bar=/tmp/bar",
-						"emptyDirVolumeMounts": "baz=/tmp/baz,quux=/tmp/quux",
+						"journalDirectories":    "/bk/journal/j0,/bk/journal/j1,/bk/journal/j2,/bk/journal/j3",
+						"ledgerDirectories":     "/bk/ledgers/l0,/bk/ledgers/l1,/bk/ledgers/l2,/bk/ledgers/l3",
+						"indexDirectories":      "/bk/index/i0,/bk/index/i1",
+						"hostPathVolumeMounts":  "foo=/tmp/foo,bar=/tmp/bar",
+						"emptyDirVolumeMounts":  "baz=/tmp/baz,quux=/tmp/quux",
+						"configMapVolumeMounts": "bk-log4j:log4j.properties=/opt/bookkeeper/conf/log4j.properties",
 					},
 					Labels: map[string]string{
 						"bookie-name": "dummyBookie",
@@ -157,6 +158,11 @@ var _ = Describe("Bookie", func() {
 					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[13].MountPath
 					Ω(mounthostpath0).Should(Equal("/tmp/baz"))
 					Ω(mounthostpath1).Should(Equal("/tmp/quux"))
+				})
+				It("should have configMapVolumeMounts set to the values given by user", func() {
+					sts := bookkeepercluster.MakeBookieStatefulSet(bk)
+					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[14].MountPath
+					Ω(mounthostpath0).Should(Equal("/opt/bookkeeper/conf/log4j.properties"))
 				})
 
 				It("should have probe timeout values set to the values given by user", func() {


### PR DESCRIPTION
### Change log description

- introduces the configMapVolumeMounts option as multiple key-value pairs, separated by commas and each consisting of a <configMapName>:<configKey>=<configFilePath> tuple.
- parses the configMapVolumeMounts values.
- adds the extracted values to the volumes list and containers' volumeMounts list.

### Purpose of the change

Implements #83 

Bookkeeper operator should allow to specify "extra" configmap volumes to be mounted into bookie pods. Such config volumes may be used to import external configs for bookie use, such as log config.
### What the code does

The code implements the new bookkeeper option configMapVolumeMounts.
To use "extra" volumes in the bookkeeper pods, in the bookkeeper options, specify:

configMapVolumeMounts to add configMap volumes
The option consist of multiple key-value pairs, separated by commas and each consisting of a <configMapName>:<configKey>=<configFilePath> tuple:

<configMapName> is the name of the configmap to be mounted.
<configKey> is the key (file name) of the configmap data.
<configFilePath> is the path of the config file inside the container to be overriden..
For example, configMapVolumeMounts: "bk-log4j:log4j.properties=/opt/bookkeeper/conf/log4j.properties"

### How to verify it

Add the configMapVolumeMounts option to bookkeeper options parameter, e.g., configMapVolumeMounts: "bk-log4j:log4j.properties=/opt/bookkeeper/conf/log4j.properties".
When the bookkeeper cluster is deployed and ready, make sure that the the volumes list and containers' volumeMounts list has contained the configMapVolumeMounts volumes and mounts specified in the configMapVolumeMounts. In addition, make sure that the config file inside the bookkeeper pods has been overriden by the data in the config map.
The function has worked as expected on the deployed bookkeeper cluster in our environment. We've already successfully both the positive and negative test cases. In the negative case, I've also verified successfully the scenario that the bookkeeper is install successfully as originally expected without all the customized pod labels and extra volume mounts parameters.
