### PR TITLE
Issue 129: Making JVM options configurable

### DIFF
--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -172,9 +172,9 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 | `storage.journal.volumeSize` | Requested size for bookkeeper journal persistent volumes | `10Gi` |
 | `storage.index.className` | Storage class name for bookkeeper index | `` |
 | `storage.index.volumeSize` | Requested size for bookkeeper index persistent volumes | `10Gi` |
-| `jvmOptions.memoryOpts` | Memory Options passed to the JVM for bookkeeper performance tuning | `["-Xms1g", "-XX:MaxDirectMemorySize=2g"]` |
-| `jvmOptions.gcOpts` | Garbage Collector (GC) Options passed to the JVM for bookkeeper bookkeeper performance tuning | `[]` |
+| `jvmOptions.memoryOpts` | Memory Options passed to the JVM for bookkeeper performance tuning | `["-Xms1g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=50.0"]` |
+| `jvmOptions.gcOpts` | Garbage Collector (GC) Options passed to the JVM for bookkeeper bookkeeper performance tuning | `["-XX:+UseG1GC", "-XX:MaxGCPauseMillis=10", "-XX:+ParallelRefProcEnabled", "-XX:+DoEscapeAnalysis", "-XX:ParallelGCThreads=32", "-XX:ConcGCThreads=32", "-XX:G1NewSizePercent=50", "-XX:+DisableExplicitGC", "-XX:-ResizePLAB"]` |
 | `jvmOptions.gcLoggingOpts` | GC Logging Options passed to the JVM for bookkeeper performance tuning | `["-Xlog:gc*,safepoint::time,level,tags:filecount=5,filesize=64m"]` |
-| `jvmOptions.extraOpts` | Extra Options passed to the JVM for bookkeeper performance tuning | `["-XX:+IgnoreUnrecognizedVMOptions"]` |
+| `jvmOptions.extraOpts` | Extra Options passed to the JVM for bookkeeper performance tuning | `[]` |
 | `options` | List of bookkeeper options | |
 | `labels` | Labels to be added to the Bookie Pods | |

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -56,13 +56,13 @@ storage:
     volumeSize: 10Gi
 
 jvmOptions:
-  memoryOpts: ["-Xms1g", "-XX:MaxDirectMemorySize=2g"]
-  gcOpts: []
+  memoryOpts: ["-Xms1g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=50.0"]
+  gcOpts: ["-XX:+UseG1GC", "-XX:MaxGCPauseMillis=10", "-XX:+ParallelRefProcEnabled", "-XX:+DoEscapeAnalysis", "-XX:ParallelGCThreads=32", "-XX:ConcGCThreads=32", "-XX:G1NewSizePercent=50", "-XX:+DisableExplicitGC", "-XX:-ResizePLAB"]
   ## GC logging for Java 9+
   gcLoggingOpts: ["-Xlog:gc*,safepoint::time,level,tags:filecount=5,filesize=64m"]
   ## GC logging for Java 8
   # gcLoggingOpts: ["-XX:+PrintGCDetails","-XX:+PrintGCApplicationStoppedTime","-XX:+UseGCLogFileRotation","-XX:NumberOfGCLogFiles=5","-XX:GCLogFileSize=64m"]
-  extraOpts: ["-XX:+IgnoreUnrecognizedVMOptions"]
+  extraOpts: []
 
 options:
   useHostNameAsBookieID: "true"

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -56,7 +56,7 @@ storage:
     volumeSize: 10Gi
 
 jvmOptions:
-  memoryOpts: ["-Xms1g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=50.0"]
+  memoryOpts: ["-Xms1g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=50.0"]
   gcOpts: ["-XX:+UseG1GC", "-XX:MaxGCPauseMillis=10", "-XX:+ParallelRefProcEnabled", "-XX:+DoEscapeAnalysis", "-XX:ParallelGCThreads=32", "-XX:ConcGCThreads=32", "-XX:G1NewSizePercent=50", "-XX:+DisableExplicitGC", "-XX:-ResizePLAB"]
   ## GC logging for Java 9+
   gcLoggingOpts: ["-Xlog:gc*,safepoint::time,level,tags:filecount=5,filesize=64m"]
@@ -86,5 +86,5 @@ options:
   # enableStatistics: "true"
   # statsProviderClass: "org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider"
   # hostPathVolumeMounts: "foo=/tmp/foo,bar=/tmp/bar"
-  # emptyDirVolumeMounts: "heap-dump=/tmp/dumpfile/heap,log=/opt/bookkeeper/logs"
+  emptyDirVolumeMounts: "heap-dump=/tmp/dumpfile/heap"
   # configMapVolumeMounts: "bk-log4j:log4j.properties=/opt/bookkeeper/conf/log4j.properties"

--- a/charts/bookkeeper/values/large.yaml
+++ b/charts/bookkeeper/values/large.yaml
@@ -10,17 +10,14 @@ resources:
 
 storage:
   ledger:
-    className: standard
+    className:
     volumeSize: 250Gi
   journal:
-    className: standard
+    className:
     volumeSize: 250Gi
   index:
-    className: standard
+    className:
     volumeSize: 10Gi
 
 jvmOptions:
   memoryOpts: ["-Xms2g", "-XX:MaxDirectMemorySize=8g"]
-  gcOpts: []
-  gcLoggingOpts: []
-  extraOpts: []

--- a/charts/bookkeeper/values/medium.yaml
+++ b/charts/bookkeeper/values/medium.yaml
@@ -10,17 +10,14 @@ resources:
 
 storage:
   ledger:
-    className: standard
+    className:
     volumeSize: 100Gi
   journal:
-    className: standard
+    className:
     volumeSize: 100Gi
   index:
-    className: standard
+    className:
     volumeSize: 10Gi
 
 jvmOptions:
   memoryOpts: ["-Xms2g", "-XX:MaxDirectMemorySize=4g"]
-  gcOpts: []
-  gcLoggingOpts: []
-  extraOpts: []

--- a/charts/bookkeeper/values/minikube.yaml
+++ b/charts/bookkeeper/values/minikube.yaml
@@ -10,13 +10,13 @@ resources:
 
 storage:
   ledger:
-    className: standard
+    className:
     volumeSize: 10Gi
   journal:
-    className: standard
+    className:
     volumeSize: 10Gi
   index:
-    className: standard
+    className:
     volumeSize: 10Gi
 
 jvmOptions:

--- a/charts/bookkeeper/values/small.yaml
+++ b/charts/bookkeeper/values/small.yaml
@@ -10,17 +10,14 @@ resources:
 
 storage:
   ledger:
-    className: standard
+    className:
     volumeSize: 100Gi
   journal:
-    className: standard
+    className:
     volumeSize: 100Gi
   index:
-    className: standard
+    className:
     volumeSize: 10Gi
 
 jvmOptions:
   memoryOpts: ["-Xms1g", "-XX:MaxDirectMemorySize=2g"]
-  gcOpts: []
-  gcLoggingOpts: []
-  extraOpts: []

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -168,8 +168,10 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 	if _, ok = bk.Spec.Options["configMapVolumeMounts"]; ok {
 		configMapVolumeMounts = strings.Split(bk.Spec.Options["configMapVolumeMounts"], ",")
 	}
+
 	var volumes []corev1.Volume
 	var cmVolumeMounts []corev1.VolumeMount
+
 	if len(configMapVolumeMounts) > 0 {
 		for _, vm := range configMapVolumeMounts {
 			p := strings.Split(vm, "=")
@@ -194,8 +196,7 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 			cmVolumeMounts = append(cmVolumeMounts, m)
 		}
 	}
-
-	if len(hostPathVolumeMounts) > 1 {
+	if len(hostPathVolumeMounts) > 0 {
 		for _, vm := range hostPathVolumeMounts {
 			s := strings.Split(vm, "=")
 			v := corev1.Volume{
@@ -209,7 +210,7 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 			volumes = append(volumes, v)
 		}
 	}
-	if len(emptyDirVolumeMounts) > 1 {
+	if len(emptyDirVolumeMounts) > 0 {
 		for _, vm := range emptyDirVolumeMounts {
 			s := strings.Split(vm, "=")
 			v := corev1.Volume{
@@ -221,8 +222,10 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 			volumes = append(volumes, v)
 		}
 	}
+
 	volumeMounts := createVolumeMount(ledgerDirs, journalDirs, indexDirs,
 		ledgerSubPath, journalSubPath, indexSubPath, hostPathVolumeMounts, emptyDirVolumeMounts)
+
 	if len(cmVolumeMounts) > 0 {
 		volumeMounts = append(volumeMounts, cmVolumeMounts...)
 	}
@@ -337,7 +340,7 @@ func createVolumeMount(ledgerDirs []string, journalDirs []string, indexDirs []st
 		}
 		volumeMounts = append(volumeMounts, v)
 	}
-	if len(hostPathVolumeMounts) > 1 {
+	if len(hostPathVolumeMounts) > 0 {
 		for _, vm := range hostPathVolumeMounts {
 			s := strings.Split(vm, "=")
 			v := corev1.VolumeMount{
@@ -347,7 +350,7 @@ func createVolumeMount(ledgerDirs []string, journalDirs []string, indexDirs []st
 			volumeMounts = append(volumeMounts, v)
 		}
 	}
-	if len(emptyDirVolumeMounts) > 1 {
+	if len(emptyDirVolumeMounts) > 0 {
 		for _, vm := range emptyDirVolumeMounts {
 			s := strings.Split(vm, "=")
 			v := corev1.VolumeMount{

--- a/pkg/controller/bookkeepercluster/bookie_test.go
+++ b/pkg/controller/bookkeepercluster/bookie_test.go
@@ -223,11 +223,6 @@ var _ = Describe("Bookie", func() {
 					indexjournal := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
 					Ω(indexjournal).Should(Equal("/bk/index"))
 				})
-				It("should have emptyDirVolumeMounts set to default value", func() {
-					sts := bookkeepercluster.MakeBookieStatefulSet(bk)
-					mountledger := sts.Spec.Template.Spec.Containers[0].VolumeMounts[3].MountPath
-					Ω(mountledger).Should(Equal("/tmp/dumpfile/heap"))
-				})
 
 				It("should have probe timeout values set to their default value", func() {
 					rp_i := bk.Spec.Probes.ReadinessProbe.InitialDelaySeconds

--- a/pkg/controller/bookkeepercluster/bookie_test.go
+++ b/pkg/controller/bookkeepercluster/bookie_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Bookie", func() {
 				},
 			}
 		})
-		Context("User is specifying bookkeeper journal and ledger path ", func() {
+		Context("User is specifying bookkeeper journal and ledger path", func() {
 
 			var (
 				customReq *corev1.ResourceRequirements
@@ -159,6 +159,7 @@ var _ = Describe("Bookie", func() {
 					Ω(mounthostpath0).Should(Equal("/tmp/baz"))
 					Ω(mounthostpath1).Should(Equal("/tmp/quux"))
 				})
+
 				It("should have configMapVolumeMounts set to the values given by user", func() {
 					sts := bookkeepercluster.MakeBookieStatefulSet(bk)
 					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[14].MountPath
@@ -189,9 +190,15 @@ var _ = Describe("Bookie", func() {
 				})
 			})
 		})
-		Context("User is not specifying bookkeeper journal and ledger path ", func() {
+
+		Context("User is not specifying bookkeeper journal and ledger path", func() {
 			BeforeEach(func() {
-				bk.Spec = v1alpha1.BookkeeperClusterSpec{}
+				bk.Spec = v1alpha1.BookkeeperClusterSpec{
+					Options: map[string]string{
+						"hostPathVolumeMounts": "foo=/tmp/foo",
+						"emptyDirVolumeMounts": "baz=/tmp/baz",
+					},
+				}
 				bk.WithDefaults()
 			})
 			Context("Bookkeeper", func() {
@@ -214,6 +221,7 @@ var _ = Describe("Bookie", func() {
 					ss := bookkeepercluster.MakeBookieStatefulSet(bk)
 					Ω(ss.Name).Should(Equal(util.StatefulSetNameForBookie(bk.Name)))
 				})
+
 				It("should have journal and ledgers dir set to default value", func() {
 					sts := bookkeepercluster.MakeBookieStatefulSet(bk)
 					mountledger := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
@@ -222,6 +230,18 @@ var _ = Describe("Bookie", func() {
 					Ω(mountjournal).Should(Equal("/bk/journal"))
 					indexjournal := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
 					Ω(indexjournal).Should(Equal("/bk/index"))
+				})
+
+				It("should have hostPathVolumeMounts set to the value given by user", func() {
+					sts := bookkeepercluster.MakeBookieStatefulSet(bk)
+					mounthostpath := sts.Spec.Template.Spec.Containers[0].VolumeMounts[3].MountPath
+					Ω(mounthostpath).Should(Equal("/tmp/foo"))
+				})
+
+				It("should have emptyDirVolumeMounts set to the value given by user", func() {
+					sts := bookkeepercluster.MakeBookieStatefulSet(bk)
+					mounthostpath := sts.Spec.Template.Spec.Containers[0].VolumeMounts[4].MountPath
+					Ω(mounthostpath).Should(Equal("/tmp/baz"))
 				})
 
 				It("should have probe timeout values set to their default value", func() {

--- a/pkg/test/e2e/e2eutil/bkcluster_util.go
+++ b/pkg/test/e2e/e2eutil/bkcluster_util.go
@@ -237,22 +237,19 @@ func CheckEvents(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, b
 	return false, nil
 }
 
-func CheckConfigMap(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, b *bkapi.BookkeeperCluster) (bool, error) {
+func CheckConfigMap(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, b *bkapi.BookkeeperCluster, key string, value string) error {
 	cm := &corev1.ConfigMap{}
 	name := util.ConfigMapNameForBookie(b.Name)
 	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: b.Namespace, Name: name}, cm)
 	if err != nil {
-		return false, fmt.Errorf("failed to obtain configmap: %v", err)
+		return fmt.Errorf("failed to obtain configmap: %v", err)
 	}
 	if cm != nil {
-		if cm.Data["BK_autoRecoveryDaemonEnabled"] == "true" {
-			return true, nil
-		} else if cm.Data["BK_autoRecoveryDaemonEnabled"] == "false" {
-			return false, nil
+		if cm.Data[key] == value {
+			return nil
 		}
 	}
-
-	return false, fmt.Errorf("BK_autoRecoveryDaemonEnabled not found")
+	return fmt.Errorf("Configmap does not contain the expected value")
 }
 
 // WaitForBookkeeperClusterToBecomeReady will wait until all Bookkeeper cluster pods are ready

--- a/test/e2e/multiple_bk_test.go
+++ b/test/e2e/multiple_bk_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	bookkeeper_e2eutil "github.com/pravega/bookkeeper-operator/pkg/test/e2e/e2eutil"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -52,9 +53,8 @@ func testMultiBKCluster(t *testing.T) {
 
 	bk1, err = bookkeeper_e2eutil.GetBKCluster(t, f, ctx, bk1)
 	g.Expect(err).NotTo(HaveOccurred())
-	value, err := bookkeeper_e2eutil.CheckConfigMap(t, f, ctx, bk1)
+	err = bookkeeper_e2eutil.CheckConfigMap(t, f, ctx, bk1, "BK_autoRecoveryDaemonEnabled", strconv.FormatBool(autorecovery))
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(value).To(Equal(autorecovery))
 
 	// Create second cluster
 	cluster = bookkeeper_e2eutil.NewDefaultCluster(namespace)
@@ -75,9 +75,8 @@ func testMultiBKCluster(t *testing.T) {
 
 	bk2, err = bookkeeper_e2eutil.GetBKCluster(t, f, ctx, bk2)
 	g.Expect(err).NotTo(HaveOccurred())
-	value, err = bookkeeper_e2eutil.CheckConfigMap(t, f, ctx, bk2)
+	err = bookkeeper_e2eutil.CheckConfigMap(t, f, ctx, bk2, "BK_autoRecoveryDaemonEnabled", strconv.FormatBool(autorecovery))
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(value).To(Equal(autorecovery))
 
 	// Create third cluster
 	cluster = bookkeeper_e2eutil.NewDefaultCluster(namespace)


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Removes the hardcoded JVM options from the operator code, so that users can easily set their desired configuration through the charts, and also modify them if required.

### Purpose of the change
Fixes #129 

### What the code does
Removes the hardcoded JVM options from the operator code.

### How to verify it
The bookkeeper cluster should be configured with the JVM options (i.e. memoryOpts, gcOpts, gcLoggingOpts, extraOpts) that are provided within the values.yaml by the user. Also these values can be easily modified even after the bookkeeper cluster has been deployed by editing the bookkeeper cluster configmap.
