### PR TITLE
Issue 131: add bookie pods annotation

### DIFF
--- a/charts/bookkeeper-operator/templates/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
+++ b/charts/bookkeeper-operator/templates/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
@@ -838,6 +838,11 @@ spec:
                 type: string
               description: Labels to be added to the Bookie Pods
               type: object
+            annotations:
+              additionalProperties:
+                type: string
+              description: annotations to be added to the Bookie Pods
+              type: object
             storage:
               description: Storage configures the storage for BookKeeper
               properties:

--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -178,3 +178,4 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 | `jvmOptions.extraOpts` | Extra Options passed to the JVM for bookkeeper performance tuning | `[]` |
 | `options` | List of bookkeeper options | |
 | `labels` | Labels to be added to the Bookie Pods | |
+| `annotations` | Annotations to be added to the Bookie Pods | |

--- a/charts/bookkeeper/templates/bookkeeper.yaml
+++ b/charts/bookkeeper/templates/bookkeeper.yaml
@@ -29,6 +29,8 @@ spec:
   {{- end }}
   labels:
 {{ toYaml .Values.labels | indent 4 }}
+  annotations:
+{{ toYaml .Values.annotations | indent 4 }}
   {{- if .Values.probes }}
   probes:
     {{- if .Values.probes.readiness }}

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -22,6 +22,7 @@ autoRecovery: true
 blockOwnerDeletion: true
 affinity: {}
 labels: {}
+annotations: {}
 probes:
   readiness:
     initialDelaySeconds: 20

--- a/deploy/crds/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
+++ b/deploy/crds/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
@@ -837,6 +837,11 @@ spec:
                 type: string
               description: Labels to be added to the Bookie Pods
               type: object
+            annotations:
+              additionalProperties:
+                type: string
+              description: annotations to be added to the Bookie Pods
+              type: object
             storage:
               description: Storage configures the storage for BookKeeper
               properties:

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -515,6 +515,10 @@ func (s *BookkeeperClusterSpec) withDefaults(bk *BookkeeperCluster) (changed boo
 		s.Labels = map[string]string{}
 	}
 
+	if s.Annotations == nil {
+		s.Annotations = map[string]string{}
+	}
+
 	return changed
 }
 

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -512,10 +512,12 @@ func (s *BookkeeperClusterSpec) withDefaults(bk *BookkeeperCluster) (changed boo
 	}
 
 	if s.Labels == nil {
+		changed = true
 		s.Labels = map[string]string{}
 	}
 
 	if s.Annotations == nil {
+		changed = true
 		s.Annotations = map[string]string{}
 	}
 

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -251,6 +251,10 @@ type BookkeeperClusterSpec struct {
 	// Labels to be added to the bookie pods
 	// +optional
 	Labels map[string]string `json:"labels"`
+
+	// Annotations to be added to the bookie pods
+	// +optional
+	Annotations map[string]string `json:"annotations"`
 }
 
 // BookkeeperImageSpec defines the fields needed for a BookKeeper Docker image
@@ -659,6 +663,16 @@ func (bk *BookkeeperCluster) LabelsForBookie() map[string]string {
 	}
 	labels["component"] = "bookie"
 	return labels
+}
+
+func (bk *BookkeeperCluster) AnnotationsForBookie() map[string]string {
+	annotations := map[string]string{"bookkeeper.version": bk.Spec.Version}
+	if bk.Spec.Annotations != nil {
+		for k, v := range bk.Spec.Annotations {
+			annotations[k] = v
+		}
+	}
+	return annotations
 }
 
 func (bookkeeperCluster *BookkeeperCluster) LabelsForBookkeeperCluster() map[string]string {

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types_test.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types_test.go
@@ -106,7 +106,8 @@ var _ = Describe("BookkeeperCluster Types Spec", func() {
 
 			bk = &v1alpha1.BookkeeperCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
+					Name:        "default",
+					Annotations: bk.AnnotationsForBookie(),
 				},
 			}
 			bk.WithDefaults()

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types_test.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types_test.go
@@ -191,6 +191,7 @@ var _ = Describe("BookkeeperCluster Types Spec", func() {
 					Name: "default",
 				},
 			}
+			bk.Spec.Labels = map[string]string{"bookkeeperLabel": "dummyLabel"}
 			str1 = bk.LabelsForBookie()
 		})
 		It("should return label for app", func() {

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types_test.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types_test.go
@@ -106,11 +106,12 @@ var _ = Describe("BookkeeperCluster Types Spec", func() {
 
 			bk = &v1alpha1.BookkeeperCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "default",
-					Annotations: bk.AnnotationsForBookie(),
+					Name: "default",
 				},
 			}
 			bk.WithDefaults()
+			bk.Spec.Annotations = map[string]string{"bookkeeperAnnotation": "dummyAnnotation"}
+			bk.Annotations = bk.AnnotationsForBookie()
 			s := scheme.Scheme
 			s.AddKnownTypes(v1alpha1.SchemeGroupVersion, bk)
 

--- a/pkg/apis/bookkeeper/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/bookkeeper/v1alpha1/zz_generated.deepcopy.go
@@ -127,6 +127,13 @@ func (in *BookkeeperClusterSpec) DeepCopyInto(out *BookkeeperClusterSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -61,9 +61,10 @@ func MakeBookieStatefulSet(bk *v1alpha1.BookkeeperCluster) *appsv1.StatefulSet {
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      util.StatefulSetNameForBookie(bk.Name),
-			Namespace: bk.Namespace,
-			Labels:    bk.LabelsForBookie(),
+			Name:        util.StatefulSetNameForBookie(bk.Name),
+			Namespace:   bk.Namespace,
+			Labels:      bk.LabelsForBookie(),
+			Annotations: bk.AnnotationsForBookie(),
 		},
 		Spec: appsv1.StatefulSetSpec{
 			ServiceName:         util.HeadlessServiceNameForBookie(bk.Name),
@@ -85,7 +86,7 @@ func MakeBookiePodTemplate(bk *v1alpha1.BookkeeperCluster) corev1.PodTemplateSpe
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      bk.LabelsForBookie(),
-			Annotations: map[string]string{"bookkeeper.version": bk.Spec.Version},
+			Annotations: bk.AnnotationsForBookie(),
 		},
 		Spec: *makeBookiePodSpec(bk),
 	}

--- a/pkg/controller/bookkeepercluster/bookie_test.go
+++ b/pkg/controller/bookkeepercluster/bookie_test.go
@@ -97,6 +97,9 @@ var _ = Describe("Bookie", func() {
 					Labels: map[string]string{
 						"bookie-name": "dummyBookie",
 					},
+					Annotations: map[string]string{
+						"bookie-annotation": "dummyBookie",
+					},
 				}
 				bk.WithDefaults()
 			})
@@ -124,6 +127,7 @@ var _ = Describe("Bookie", func() {
 				It("should create a stateful set", func() {
 					ss := bookkeepercluster.MakeBookieStatefulSet(bk)
 					Ω(ss.Labels["bookie-name"]).Should(Equal("dummyBookie"))
+					Ω(ss.Annotations["bookie-annotation"]).Should(Equal("dummyBookie"))
 				})
 
 				It("should set the JVM options given by user", func() {


### PR DESCRIPTION
### Change log description

add annoation field in bookkeeeper crd and attach annotation to bookie pods and sts

### Purpose of the change

Fixes #131

### What the code does
add annoation field in bookkeeeper crd and attach annotation to bookie pods and sts


### How to verify it
set bookie pods annoation via chart values and deploy bookkeeper with the built operator. kubectl describe bookie pods to see if the specified annotation is there.
