### PR TITLE
Issue 156: Including operator base version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SHELL=/bin/bash -o pipefail
 PROJECT_NAME=bookkeeper-operator
 REPO=pravega/$(PROJECT_NAME)
 BASE_VERSION=0.1.6
-ID=$(shell git rev-list `git rev-list --tags --no-walk --max-count=1`..HEAD --count)
+ID=$(shell git rev-list HEAD --count)
 GIT_SHA=$(shell git rev-parse --short HEAD)
 VERSION=$(BASE_VERSION)-$(ID)-$(GIT_SHA)
 GOOS=linux

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ SHELL=/bin/bash -o pipefail
 
 PROJECT_NAME=bookkeeper-operator
 REPO=pravega/$(PROJECT_NAME)
-VERSION=$(shell git describe --always --tags --dirty | sed "s/\(.*\)-g`git rev-parse --short HEAD`/\1/")
+BASE_VERSION=0.1.6
+ID=$(shell git rev-list `git rev-list --tags --no-walk --max-count=1`..HEAD --count)
 GIT_SHA=$(shell git rev-parse --short HEAD)
+VERSION=$(BASE_VERSION)-$(ID)-$(GIT_SHA)
 GOOS=linux
 GOARCH=amd64
 TEST_REPO=testbkop/$(PROJECT_NAME)

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: bookkeeper-operator
       containers:
         - name: bookkeeper-operator
-          image: pravega/bookkeeper-operator:0.1.4
+          image: pravega/bookkeeper-operator:0.1.5
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Hardcodes the base version of the operator in the Makefile, which needs to be updated after every bookkeeper operator release, to serve as the base version.

### Purpose of the change
Fixes #156 

### What the code does
Hardcodes the bookkeeper operator base version in the Makefile to compute the version for bookkeeper operator images that are build using `make build-image` command.
The final version for the bookkeeper operator is computed in the following format inside the Makefile
```
{base_version}-{number_of_commits_after_last_release}-{commit_id}
```

### How to verify it
Running the command `make build-image` should build the bookkeeper-operator image with version in the desired format
