### PR TITLE
Issue 160: Making BookieID changes backward compatible

### DIFF
--- a/pkg/controller/bookkeepercluster/bookie_test.go
+++ b/pkg/controller/bookkeepercluster/bookie_test.go
@@ -90,7 +90,6 @@ var _ = Describe("Bookie", func() {
 					Options: map[string]string{
 						"journalDirectories":    "/bk/journal/j0,/bk/journal/j1,/bk/journal/j2,/bk/journal/j3",
 						"ledgerDirectories":     "/bk/ledgers/l0,/bk/ledgers/l1,/bk/ledgers/l2,/bk/ledgers/l3",
-						"indexDirectories":      "/bk/index/i0,/bk/index/i1",
 						"hostPathVolumeMounts":  "foo=/tmp/foo,bar=/tmp/bar",
 						"emptyDirVolumeMounts":  "baz=/tmp/baz,quux=/tmp/quux",
 						"configMapVolumeMounts": "bk-log4j:log4j.properties=/opt/bookkeeper/conf/log4j.properties",
@@ -168,31 +167,29 @@ var _ = Describe("Bookie", func() {
 					Ω(mountjournal1).Should(Equal("/bk/journal/j1"))
 					Ω(mountjournal2).Should(Equal("/bk/journal/j2"))
 					Ω(mountjournal3).Should(Equal("/bk/journal/j3"))
-					mountindex0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[8].MountPath
-					mountindex1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[9].MountPath
-					Ω(mountindex0).Should(Equal("/bk/index/i0"))
-					Ω(mountindex1).Should(Equal("/bk/index/i1"))
+					mountindex := sts.Spec.Template.Spec.Containers[0].VolumeMounts[8].MountPath
+					Ω(mountindex).Should(Equal("/bk/index"))
 				})
 
 				It("should have hostPathVolumeMounts set to the values given by user", func() {
 					sts := bookkeepercluster.MakeBookieStatefulSet(bk)
-					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[10].MountPath
-					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[11].MountPath
+					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[9].MountPath
+					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[10].MountPath
 					Ω(mounthostpath0).Should(Equal("/tmp/foo"))
 					Ω(mounthostpath1).Should(Equal("/tmp/bar"))
 				})
 
 				It("should have emptyDirVolumeMounts set to the values given by user", func() {
 					sts := bookkeepercluster.MakeBookieStatefulSet(bk)
-					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[12].MountPath
-					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[13].MountPath
+					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[11].MountPath
+					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[12].MountPath
 					Ω(mounthostpath0).Should(Equal("/tmp/baz"))
 					Ω(mounthostpath1).Should(Equal("/tmp/quux"))
 				})
 
 				It("should have configMapVolumeMounts set to the values given by user", func() {
 					sts := bookkeepercluster.MakeBookieStatefulSet(bk)
-					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[14].MountPath
+					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[13].MountPath
 					Ω(mounthostpath0).Should(Equal("/opt/bookkeeper/conf/log4j.properties"))
 				})
 

--- a/test/e2e/resources/kubernetes_master_install.sh
+++ b/test/e2e/resources/kubernetes_master_install.sh
@@ -27,8 +27,8 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" \
   && sudo apt-get update
 sudo apt-get update \
   && sudo apt-get install -yq \
-  kubelet \
-  kubeadm \
+  kubelet=1.21.2-00 \
+  kubeadm=1.21.2-00 \
   kubernetes-cni
 sudo apt-mark hold kubelet kubeadm kubectl
 UUID=`cat /etc/fstab | grep swap | awk '{print $1}' | tr -d "#UUID="`

--- a/test/e2e/resources/kubernetes_slave_install.sh
+++ b/test/e2e/resources/kubernetes_slave_install.sh
@@ -11,19 +11,19 @@ sudo apt install docker.io -y
 echo "docker install"
 sudo systemctl enable --now docker
 apt-get update && apt-get install -y \
-  apt-transport-https ca-certificates curl software-properties-common gnupg2 
+  apt-transport-https ca-certificates curl software-properties-common gnupg2
 echo "installed certs"
 sudo curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" \
   | sudo tee -a /etc/apt/sources.list.d/kubernetes.list \
-  && sudo apt-get update 
+  && sudo apt-get update
 sudo apt-get update \
   && sudo apt-get install -yq \
-  kubelet \
-  kubeadm \
+  kubelet=1.21.2-00 \
+  kubeadm=1.21.2-00 \
   kubernetes-cni
 sudo apt-mark hold kubelet kubeadm kubectl
-UUID=`cat /etc/fstab | grep swap | awk '{print $1}' | tr -d "#UUID="` 
+UUID=`cat /etc/fstab | grep swap | awk '{print $1}' | tr -d "#UUID="`
 sed -i '2 s/^/#/' /etc/fstab
 echo "swapoff UUID=$UUID"
 swapoff UUID=$UUID


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
We need a workaound to prevent upgrades from an older bookkeeper version to the bookkeeper version (which contains [this](https://github.com/pravega/pravega/pull/6222) fix) from breaking. Without this change, an upgrade would fail with an `InvalidCookieException` due to a mismatch in the BookieID of the bookeeper instances post upgrade.

### Purpose of the change
Fixes #160 #112 

### What the code does
Exposes a new bookkeeper option namely `setNewBookieID` which when set to `false` would enforce the bookkeeper instances to follow the old nomenclature for BookieIDs, and when set to `true` would enforce the bookkeeper instances to follow the new nomenclature for BookieIDs

### How to verify it
Following are the various use cases that have been verified
- old version of bookkeeper operator
  old version of bookkeeper
  upgraded bookkeeper to latest version (takes BK_setNewBookieID=false by default) - (computes BookieID from hostname and persists it in a file within a journal subdirectory)
  upgraded bookkeeper operator to latest version
  (this approach uses older nomenclature for BookieID as expected)
  (every subsequent bookkeeper upgrade would need to pass the additional bookkeeper option setNewBookieID=false)

- old version of bookkeeper operator
  old version of bookkeeper
  upgraded bookkeeper operator to latest version
  upgraded bookkeeper to latest version (need to provide the additional bookkeeper option setNewBookieID=false since bookkeeper version >= 0.10.0)
  (this approach uses older nomenclature for BookieID as expected)
  (every subsequent bookkeeper upgrade would need to pass the additional bookkeeper option setNewBookieID=false)

- latest version of bookkeeper operator (i.e. one which contains [this](https://github.com/pravega/bookkeeper-operator/pull/161) fix)
  old version of bookkeeper (since bookkeeper version < 0.10.0 takes BK_setNewBookieID=false by default)
  upgraded bookkeeper to latest version (need to provide the additional bookkeeper option setNewBookieID=false since bookkeeper version >= 0.10.0)
  (this approach uses older nomenclature for BookieID as expected)
  (every subsequent bookkeeper upgrade would need to pass the additional bookkeeper option setNewBookieID=false)

- latest version of bookkeeper operator (i.e. one which contains [this](https://github.com/pravega/bookkeeper-operator/pull/161) fix)
  latest version of bookkeeper (since bookkeeper version >= 0.10.0 takes BK_setNewBookieID=true by default)
  deletion of pod should cause it to read the BookieID from the persisted file
  scale down followed by a scale up will not find any BookieID stored and will therefore generate a new BookieID and persist it
  (this approach uses new nomenclature for BookieID as expected) 
