### PR TITLE
Issue 160: Making BookieID change backward compatible

### DIFF
--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -745,6 +745,12 @@ func (bk *BookkeeperCluster) validateConfigMap() error {
 			return fmt.Errorf("failed to get configmap (%s): %v", configmap.Name, err)
 		}
 	}
+	if val, ok := bk.Spec.Options["useHostNameAsBookieID"]; ok {
+		eq := configmap.Data["BK_useHostNameAsBookieID"] == val
+		if !eq {
+			return fmt.Errorf("value of useHostNameAsBookieID should not be changed")
+		}
+	}
 	if val, ok := bk.Spec.Options["journalDirectories"]; ok {
 		eq := configmap.Data["BK_journalDirectories"] == val
 		if !eq {

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -275,6 +275,13 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 					SuccessThreshold:    bk.Spec.Probes.LivenessProbe.SuccessThreshold,
 					TimeoutSeconds:      bk.Spec.Probes.LivenessProbe.TimeoutSeconds,
 				},
+				Lifecycle: &corev1.Lifecycle{
+					PreStop: &corev1.Handler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"/bin/sh", "-c", "/opt/bookkeeper/scripts/bookkeeperTeardown.sh"},
+						},
+					},
+				},
 			},
 		},
 		Affinity: bk.Spec.Affinity,

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
@@ -205,7 +205,7 @@ func (r *ReconcileBookkeeperCluster) deployBookie(p *bookkeeperv1alpha1.Bookkeep
 		_, pravegaClusterName := getFinalizerAndClusterName(p.ObjectMeta.Finalizers)
 		err = util.CreateZnode(p.Spec.ZookeeperUri, p.Namespace, pravegaClusterName, p.Spec.Replicas)
 		if err != nil {
-			return err
+			log.Printf("failed to create znode: %v", err)
 		}
 	}
 
@@ -233,7 +233,7 @@ func (r *ReconcileBookkeeperCluster) syncBookieSize(bk *bookkeeperv1alpha1.Bookk
 			_, pravegaClusterName := getFinalizerAndClusterName(bk.ObjectMeta.Finalizers)
 			err = util.UpdateZnode(bk.Spec.ZookeeperUri, bk.Namespace, pravegaClusterName, bk.Spec.Replicas)
 			if err != nil {
-				return err
+				log.Printf("failed to update znode: %v", err)
 			}
 		}
 		sts.Spec.Replicas = &(bk.Spec.Replicas)

--- a/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
+++ b/pkg/controller/bookkeepercluster/bookkeepercluster_controller.go
@@ -203,7 +203,7 @@ func (r *ReconcileBookkeeperCluster) deployBookie(p *bookkeeperv1alpha1.Bookkeep
 
 	if util.ContainsStringWithPrefix(p.ObjectMeta.Finalizers, util.ZkFinalizer) {
 		_, pravegaClusterName := getFinalizerAndClusterName(p.ObjectMeta.Finalizers)
-		err = util.CreateZnode(p.Spec.ZookeeperUri, p.Namespace, pravegaClusterName, p.Spec.Replicas)
+		err = util.CreateClusterSizeZnode(p.Spec.ZookeeperUri, p.Namespace, pravegaClusterName, p.Spec.Replicas)
 		if err != nil {
 			log.Printf("failed to create znode: %v", err)
 		}
@@ -231,7 +231,7 @@ func (r *ReconcileBookkeeperCluster) syncBookieSize(bk *bookkeeperv1alpha1.Bookk
 	if *sts.Spec.Replicas != bk.Spec.Replicas {
 		if util.ContainsStringWithPrefix(bk.ObjectMeta.Finalizers, util.ZkFinalizer) {
 			_, pravegaClusterName := getFinalizerAndClusterName(bk.ObjectMeta.Finalizers)
-			err = util.UpdateZnode(bk.Spec.ZookeeperUri, bk.Namespace, pravegaClusterName, bk.Spec.Replicas)
+			err = util.UpdateClusterSizeZnode(bk.Spec.ZookeeperUri, bk.Namespace, pravegaClusterName, bk.Spec.Replicas)
 			if err != nil {
 				log.Printf("failed to update znode: %v", err)
 			}

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -85,7 +85,7 @@ func CreateZnode(uri string, namespace string, name string, replicas int32) (err
 	} else {
 		data := "CLUSTER_SIZE=" + strconv.Itoa(int(replicas))
 		if _, err := conn.Create(zNodePath, []byte(data), 0, zk.WorldACL(zk.PermAll)); err != nil {
-			return fmt.Errorf("Error creating znode: %s: %v", zNodePath, err)
+			return fmt.Errorf("failed to create znode (%s) : %v", zNodePath, err)
 		}
 	}
 	return nil
@@ -107,7 +107,7 @@ func UpdateZnode(uri string, namespace string, name string, replicas int32) (err
 	if exist {
 		data := "CLUSTER_SIZE=" + strconv.Itoa(int(replicas))
 		if _, err := conn.Set(zNodePath, []byte(data), zNodeStat.Version); err != nil {
-			return fmt.Errorf("Error updating zkNode: %v", err)
+			return fmt.Errorf("failed to update znode (%s) : %v", zNodePath, err)
 		}
 	}
 	return nil

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -55,7 +55,6 @@ func getHost(uri string, namespace string) []string {
 	} else {
 		hostname = zkSvcName + "." + namespace + ".svc.cluster.local:" + zkSvcPort
 	}
-	fmt.Println("ZK hostname : ", hostname)
 	return []string{hostname}
 }
 

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -26,7 +26,7 @@ var (
 )
 
 const (
-	// Set in https://github.com/pravega/bookkeeper/blob/master/docker/bookkeeper/entrypoint.sh#L21
+	// Set in https://github.com/pravega/pravega/blob/master/docker/bookkeeper/entrypoint.sh#L33
 	PravegaPath        = "pravega"
 	ZkFinalizer        = "cleanUpZookeeper"
 	IPRegexp    string = `([1-9][0-9]*\.[0-9]+\.[0-9]+\.[0-9]+)`
@@ -58,15 +58,15 @@ func getHost(uri string, namespace string) []string {
 	return []string{hostname}
 }
 
-func getRoot(name string) string {
-	return fmt.Sprintf("/%s/%s", PravegaPath, name)
+func getRoot(pravegaClusterName string) string {
+	return fmt.Sprintf("/%s/%s", PravegaPath, pravegaClusterName)
 }
 
-func getZnode(name string) string {
-	return fmt.Sprintf("%s/bookkeeper/conf", getRoot(name))
+func getZnode(pravegaClusterName string) string {
+	return fmt.Sprintf("%s/bookkeeper/conf", getRoot(pravegaClusterName))
 }
 
-func CreateZnode(uri string, namespace string, name string, replicas int32) (err error) {
+func CreateZnode(uri string, namespace string, pravegaClusterName string, replicas int32) (err error) {
 	host := getHost(uri, namespace)
 	conn, _, err := zk.Connect(host, time.Second*5)
 	if err != nil {
@@ -74,7 +74,7 @@ func CreateZnode(uri string, namespace string, name string, replicas int32) (err
 	}
 	defer conn.Close()
 
-	zNodePath := getZnode(name)
+	zNodePath := getZnode(pravegaClusterName)
 	exist, _, _ := conn.Exists(zNodePath)
 	if exist {
 		return nil

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -81,7 +81,7 @@ func CreateZnode(uri string, namespace string, pravegaClusterName string, replic
 	} else {
 		data := "CLUSTER_SIZE=" + strconv.Itoa(int(replicas))
 		if _, err := conn.Create(zNodePath, []byte(data), 0, zk.WorldACL(zk.PermAll)); err != nil {
-			return fmt.Errorf("failed to create znode (%s) : %v", zNodePath, err)
+			return fmt.Errorf("failed to create znode (%s): %v", zNodePath, err)
 		}
 	}
 	return nil
@@ -103,8 +103,10 @@ func UpdateZnode(uri string, namespace string, name string, replicas int32) (err
 	if exist {
 		data := "CLUSTER_SIZE=" + strconv.Itoa(int(replicas))
 		if _, err := conn.Set(zNodePath, []byte(data), zNodeStat.Version); err != nil {
-			return fmt.Errorf("failed to update znode (%s) : %v", zNodePath, err)
+			return fmt.Errorf("failed to update znode (%s): %v", zNodePath, err)
 		}
+	} else {
+		return fmt.Errorf("znode (%s) does not exist: %v", zNodePath, err)
 	}
 	return nil
 }

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -66,7 +66,7 @@ func getZnode(pravegaClusterName string) string {
 	return fmt.Sprintf("%s/bookkeeper/conf", getRoot(pravegaClusterName))
 }
 
-func CreateZnode(uri string, namespace string, pravegaClusterName string, replicas int32) (err error) {
+func CreateClusterSizeZnode(uri string, namespace string, pravegaClusterName string, replicas int32) (err error) {
 	host := getHost(uri, namespace)
 	conn, _, err := zk.Connect(host, time.Second*5)
 	if err != nil {
@@ -87,7 +87,7 @@ func CreateZnode(uri string, namespace string, pravegaClusterName string, replic
 	return nil
 }
 
-func UpdateZnode(uri string, namespace string, name string, replicas int32) (err error) {
+func UpdateClusterSizeZnode(uri string, namespace string, name string, replicas int32) (err error) {
 	host := getHost(uri, namespace)
 	conn, _, err := zk.Connect(host, time.Second*5)
 	if err != nil {

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -40,6 +40,7 @@ func getHost(uri string, namespace string) []string {
 	zkUri := strings.Split(uri, ":")
 	zkSvcName := ""
 	zkSvcPort := ""
+	hostname := ""
 	if len(zkUri) >= 1 {
 		zkSvcName = zkUri[0]
 		if len(zkUri) == 1 {
@@ -49,7 +50,6 @@ func getHost(uri string, namespace string) []string {
 		}
 	}
 	match := re.MatchString(zkSvcName)
-	hostname := ""
 	if match {
 		hostname = zkSvcName + ":" + zkSvcPort
 	} else {
@@ -63,7 +63,7 @@ func getRoot(name string) string {
 }
 
 func getZnode(name string) string {
-	return fmt.Sprintf("/%s/bookkeeper/conf", getRoot(name))
+	return fmt.Sprintf("%s/bookkeeper/conf", getRoot(name))
 }
 
 func CreateZnode(uri string, namespace string, name string, replicas int32) (err error) {
@@ -75,10 +75,7 @@ func CreateZnode(uri string, namespace string, name string, replicas int32) (err
 	defer conn.Close()
 
 	zNodePath := getZnode(name)
-	exist, _, err := conn.Exists(zNodePath)
-	if err != nil {
-		return fmt.Errorf("failed to check if zookeeper path exists: %v", err)
-	}
+	exist, _, _ := conn.Exists(zNodePath)
 	if exist {
 		return nil
 	} else {
@@ -101,7 +98,7 @@ func UpdateZnode(uri string, namespace string, name string, replicas int32) (err
 	zNodePath := getZnode(name)
 	exist, zNodeStat, err := conn.Exists(zNodePath)
 	if err != nil {
-		return fmt.Errorf("failed to check if zookeeper path exists: %v", err)
+		return fmt.Errorf("failed to check if znode (%s) exists: %v", zNodePath, err)
 	}
 	if exist {
 		data := "CLUSTER_SIZE=" + strconv.Itoa(int(replicas))

--- a/pkg/util/zookeeper_util.go
+++ b/pkg/util/zookeeper_util.go
@@ -13,12 +13,12 @@ package util
 import (
 	"container/list"
 	"fmt"
+	"github.com/samuel/go-zookeeper/zk"
 	"log"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
-	"github.com/samuel/go-zookeeper/zk"
 )
 
 var (
@@ -27,9 +27,9 @@ var (
 
 const (
 	// Set in https://github.com/pravega/bookkeeper/blob/master/docker/bookkeeper/entrypoint.sh#L21
-	PravegaPath = "pravega"
-	ZkFinalizer = "cleanUpZookeeper"
-	IPRegexp string = `([1-9][0-9]*\.[0-9]+\.[0-9]+\.[0-9]+)`
+	PravegaPath        = "pravega"
+	ZkFinalizer        = "cleanUpZookeeper"
+	IPRegexp    string = `([1-9][0-9]*\.[0-9]+\.[0-9]+\.[0-9]+)`
 )
 
 func init() {

--- a/pkg/util/zookeeper_util_test.go
+++ b/pkg/util/zookeeper_util_test.go
@@ -15,11 +15,11 @@ import (
 )
 
 var _ = Describe("zookeeperutil", func() {
-	Context("CreateZnode", func() {
+	Context("CreateClusterSizeZnode", func() {
 		var err1, err2 error
 		BeforeEach(func() {
-			err1 = CreateZnode("zookeeper-client:2181", "default", "pravega", 3)
-			err2 = CreateZnode("127.0.0.1:2181", "default", "pravega", 3)
+			err1 = CreateClusterSizeZnode("zookeeper-client:2181", "default", "pravega", 3)
+			err2 = CreateClusterSizeZnode("127.0.0.1:2181", "default", "pravega", 3)
 		})
 		It("should not be nil", func() {
 			Ω(err1).ShouldNot(BeNil())
@@ -27,10 +27,10 @@ var _ = Describe("zookeeperutil", func() {
 		})
 	})
 
-	Context("UpdateZnode", func() {
+	Context("UpdateClusterSizeZnode", func() {
 		var err error
 		BeforeEach(func() {
-			err = UpdateZnode("zookeeper-client:2181", "default", "pravega", 5)
+			err = UpdateClusterSizeZnode("zookeeper-client:2181", "default", "pravega", 5)
 		})
 		It("should not be nil", func() {
 			Ω(err).ShouldNot(BeNil())

--- a/pkg/util/zookeeper_util_test.go
+++ b/pkg/util/zookeeper_util_test.go
@@ -15,11 +15,31 @@ import (
 )
 
 var _ = Describe("zookeeperutil", func() {
-	Context("DeleteAllZnodes", func() {
+	Context("CreateZnode", func() {
+		var err1, err2 error
+		BeforeEach(func() {
+			err1 = CreateZnode("zookeeper-client:2181", "default", "pravega", 3)
+			err2 = CreateZnode("127.0.0.1:2181", "default", "pravega", 3)
+		})
+		It("should not be nil", func() {
+			Ω(err1).ShouldNot(BeNil())
+			Ω(err2).ShouldNot(BeNil())
+		})
+	})
 
+	Context("UpdateZnode", func() {
 		var err error
 		BeforeEach(func() {
+			err = UpdateZnode("zookeeper-client:2181", "default", "pravega", 5)
+		})
+		It("should not be nil", func() {
+			Ω(err).ShouldNot(BeNil())
+		})
+	})
 
+	Context("DeleteAllZnodes", func() {
+		var err error
+		BeforeEach(func() {
 			err = DeleteAllZnodes("zookeeper-client:2181", "default", "bookie")
 		})
 		It("should not be nil", func() {

--- a/pkg/util/zookeeper_util_test.go
+++ b/pkg/util/zookeeper_util_test.go
@@ -23,7 +23,7 @@ var _ = Describe("zookeeperutil", func() {
 		})
 		It("should not be nil", func() {
 			Ω(err1).ShouldNot(BeNil())
-			Ω(err2).ShouldNot(BeNil())
+			Ω(err2).Should(BeNil())
 		})
 	})
 

--- a/test/e2e/cmchanges_test.go
+++ b/test/e2e/cmchanges_test.go
@@ -44,6 +44,7 @@ func testCMUpgradeCluster(t *testing.T) {
 	cluster.Spec.Version = initialVersion
 	cluster.Spec.Options["minorCompactionThreshold"] = "0.4"
 	cluster.Spec.Options["journalDirectories"] = "/bk/journal"
+	cluster.Spec.Options["useHostNameAsBookieID"] = "true"
 	cluster.Spec.JVMOptions.GcOpts = gcOpts
 
 	bookkeeper, err := bookkeeper_e2eutil.CreateBKCluster(t, f, ctx, cluster)
@@ -81,7 +82,7 @@ func testCMUpgradeCluster(t *testing.T) {
 	g.Expect(bookkeeper.Spec.Version).To(Equal(upgradeVersion))
 	g.Expect(bookkeeper.Spec.Options["minorCompactionThreshold"]).To(Equal("0.5"))
 
-	// updating bookkeeper option
+	// updating bookkeeper option for journalDirectories
 	bookkeeper.Spec.Options["journalDirectories"] = "journal"
 
 	//updating bookkeepercluster
@@ -91,6 +92,17 @@ func testCMUpgradeCluster(t *testing.T) {
 	bookkeeper, err = bookkeeper_e2eutil.GetBKCluster(t, f, ctx, bookkeeper)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(bookkeeper.Spec.Options["journalDirectories"]).To(Equal("/bk/journal"))
+
+	// updating bookkeeper option for useHostNameAsBookieID
+	bookkeeper.Spec.Options["useHostNameAsBookieID"] = "false"
+
+	//updating bookkeepercluster
+	err = bookkeeper_e2eutil.UpdateBKCluster(t, f, ctx, bookkeeper)
+	g.Expect(strings.ContainsAny(err.Error(), "value of useHostNameAsBookieID should not be changed")).To(Equal(true))
+
+	bookkeeper, err = bookkeeper_e2eutil.GetBKCluster(t, f, ctx, bookkeeper)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(bookkeeper.Spec.Options["useHostNameAsBookieID"]).To(Equal("true"))
 
 	// Delete cluster
 	err = bookkeeper_e2eutil.DeleteBKCluster(t, f, ctx, bookkeeper)


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Provides a way to migrate from an older bookkeeper version to the latest bookkeeper version which contains [this](https://github.com/pravega/pravega/pull/6222) change and sets the BookieID of every new bookkeeper instance to a unique value and thereby helps prevent any data loss from happening.

### Purpose of the change
Fixes #160 

### What the code does
Creates a znode to store the bookkeeper cluster size and modify its value at the time of scale up/down; and adds a pre-stop hook to the bookie pod template, so that it invokes the bookieTeardown script at the time of the pod deletion, so that it performs a conditional cookie deletion for the pod in case the pod is being deleted as a result of a scaledown. 
It also makes the bookkeeper option `useHostNameAsBookieID` non modifiable by the user.

### How to verify it
Following are the various use cases that have been verified with I/O running in the background
- old version of bookkeeper operator
  old version of bookkeeper
  upgraded bookkeeper to latest version (computes BookieID from hostname and persists it in a file within a journal subdirectory)
  upgraded bookkeeper operator to latest version
  (this approach uses older nomenclature for BookieID as expected, and uses new nomenclature for any new bookkeeper pod that comes up as a result of any scale up)

- old version of bookkeeper operator
  old version of bookkeeper
  upgraded bookkeeper operator to latest version
  upgraded bookkeeper to latest version
  (this approach uses older nomenclature for BookieID as expected, and uses new nomenclature for any new bookkeeper pod that comes up as a result of any scale up)

- latest version of bookkeeper operator
  old version of bookkeeper
  upgraded bookkeeper to latest version
  (this approach uses older nomenclature for BookieID as expected, and uses new nomenclature for any new bookkeeper pod that comes up as a result of any scale up)

- latest version of bookkeeper operator
  latest version of bookkeeper
  deletion of pod should cause it to read the BookieID from the persisted file
  scale down followed by a scale up will not find any BookieID stored and will therefore generate a new BookieID and persist it
  (this approach uses new nomenclature for BookieID as expected) 
