### PR TITLE
Issue 90: Bookkeeper pods do not come up if storage size for index/journal/ledger volume claim templates is not mentioned

### DIFF
--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -391,7 +391,7 @@ type BookkeeperStorageSpec struct {
 }
 
 func (s *BookkeeperStorageSpec) withDefaults() (changed bool) {
-	if s.LedgerVolumeClaimTemplate == nil {
+	if s.LedgerVolumeClaimTemplate == nil || s.LedgerVolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage].Format == "" {
 		changed = true
 		s.LedgerVolumeClaimTemplate = &corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -403,7 +403,7 @@ func (s *BookkeeperStorageSpec) withDefaults() (changed bool) {
 		}
 	}
 
-	if s.JournalVolumeClaimTemplate == nil {
+	if s.JournalVolumeClaimTemplate == nil || s.JournalVolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage].Format == "" {
 		changed = true
 		s.JournalVolumeClaimTemplate = &corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -415,7 +415,7 @@ func (s *BookkeeperStorageSpec) withDefaults() (changed bool) {
 		}
 	}
 
-	if s.IndexVolumeClaimTemplate == nil {
+	if s.IndexVolumeClaimTemplate == nil || s.IndexVolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage].Format == "" {
 		changed = true
 		s.IndexVolumeClaimTemplate = &corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},


### PR DESCRIPTION
Signed-off-by: Nishant Gupta <Nishant_Gupta3@dell.com>

### Change log description

Assigns the default values to the fields of index, journal and ledgers' volume claim templates in the bookkeeper pod which are not set by the user

### Purpose of the change

Fixes #90

### What the code does

Currently the code sets the default value of the index, journal and ledger volume claim templates only if the entire volume claim templates is undefined and in case if the user does not provide few fields, it does not set them to default and throws an error. The fix to this was to check whether any of the fields is empty or not ("") and if it's true , then set them to the default values.

### How to verify it

When deploying bookkeeper using charts , only provide values to certain fields of the `bookkeeper/values.yaml `**storage** object. Below are few scenarios to test with. In all the scenarios, if any of the value is not set by the user then it should be set to default.
1) Removing/ Commenting out the entire storage object 
![image](https://user-images.githubusercontent.com/90177384/132627063-95592376-1ec4-4919-9ead-8f7120de502f.png)

2) Setting only className 
![image](https://user-images.githubusercontent.com/90177384/132627306-b70e9c38-f785-471f-ad3d-f9f914306d9e.png)

3) Setting only volumeSize 
![image](https://user-images.githubusercontent.com/90177384/132627366-35322f87-cc77-42fd-b8ea-da41187e229f.png)

4) Setting only volumeSize in certain object (say ledger) and className in other (say index) and leaving both the fields of index unset
![image](https://user-images.githubusercontent.com/90177384/132627205-9b5a3301-3ccc-4540-961f-b7de45744aca.png)

- [x] Ran e2e tests manually and they all passed
