### PR TITLE
Issue 169: Preventing modification of useHostNameAsBookieID post deployment

### DIFF
--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -745,6 +745,12 @@ func (bk *BookkeeperCluster) validateConfigMap() error {
 			return fmt.Errorf("failed to get configmap (%s): %v", configmap.Name, err)
 		}
 	}
+	if val, ok := bk.Spec.Options["useHostNameAsBookieID"]; ok {
+		eq := configmap.Data["BK_useHostNameAsBookieID"] == val
+		if !eq {
+			return fmt.Errorf("value of useHostNameAsBookieID should not be changed")
+		}
+	}
 	if val, ok := bk.Spec.Options["journalDirectories"]; ok {
 		eq := configmap.Data["BK_journalDirectories"] == val
 		if !eq {

--- a/test/e2e/cmchanges_test.go
+++ b/test/e2e/cmchanges_test.go
@@ -44,6 +44,7 @@ func testCMUpgradeCluster(t *testing.T) {
 	cluster.Spec.Version = initialVersion
 	cluster.Spec.Options["minorCompactionThreshold"] = "0.4"
 	cluster.Spec.Options["journalDirectories"] = "/bk/journal"
+	cluster.Spec.Options["useHostNameAsBookieID"] = "true"
 	cluster.Spec.JVMOptions.GcOpts = gcOpts
 
 	bookkeeper, err := bookkeeper_e2eutil.CreateBKCluster(t, f, ctx, cluster)
@@ -58,7 +59,7 @@ func testCMUpgradeCluster(t *testing.T) {
 	err = bookkeeper_e2eutil.CheckConfigMap(t, f, ctx, bookkeeper, "BOOKIE_GC_OPTS", gcOptions)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	// updating bookkeeper option
+	// updating modifiable bookkeeper option
 	gcOpts = []string{"-XX:-UseParallelGC", "-XX:MaxGCPauseMillis=10"}
 	gcOptions = strings.Join(gcOpts, " ")
 	bookkeeper.Spec.Version = upgradeVersion
@@ -81,7 +82,7 @@ func testCMUpgradeCluster(t *testing.T) {
 	g.Expect(bookkeeper.Spec.Version).To(Equal(upgradeVersion))
 	g.Expect(bookkeeper.Spec.Options["minorCompactionThreshold"]).To(Equal("0.5"))
 
-	// updating bookkeeper option
+	// updating non-modifiable bookkeeper option journalDirectories
 	bookkeeper.Spec.Options["journalDirectories"] = "journal"
 
 	//updating bookkeepercluster
@@ -91,6 +92,17 @@ func testCMUpgradeCluster(t *testing.T) {
 	bookkeeper, err = bookkeeper_e2eutil.GetBKCluster(t, f, ctx, bookkeeper)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(bookkeeper.Spec.Options["journalDirectories"]).To(Equal("/bk/journal"))
+
+	// updating non-modifiable bookkeeper option useHostNameAsBookieID
+	bookkeeper.Spec.Options["useHostNameAsBookieID"] = "false"
+
+	//updating bookkeepercluster
+	err = bookkeeper_e2eutil.UpdateBKCluster(t, f, ctx, bookkeeper)
+	g.Expect(strings.ContainsAny(err.Error(), "value of useHostNameAsBookieID should not be changed")).To(Equal(true))
+
+	bookkeeper, err = bookkeeper_e2eutil.GetBKCluster(t, f, ctx, bookkeeper)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(bookkeeper.Spec.Options["useHostNameAsBookieID"]).To(Equal("true"))
 
 	// Delete cluster
 	err = bookkeeper_e2eutil.DeleteBKCluster(t, f, ctx, bookkeeper)


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@emc.comT>

### Change log description
Disallows modification of the bookkeeper option `useHostNameAsBookieID` after the bookkeeper cluster has been deployed.

### Purpose of the change
Fixes #169 

### What the code does
An additional validation check is added in the method `validateConfigMap` which ensures that the user cannot modify the value of `useHostNameAsBookieID` post deployment.

### How to verify it
Trying to modify the value of the bookkeeper option useHostNameAsBookieID post deployment should result in the webhook throwing the following error
```
error: bookkeeperclusters.bookkeeper.pravega.io "bookkeeper" could not be patched: admission webhook "bookkeeperwebhook.pravega.io" denied the request: value of useHostNameAsBookieID should not be changed
```
