### PR TITLE
Issue 176: Provide support to add security context to bookie pods

### DIFF
--- a/deploy/crds/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
+++ b/deploy/crds/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
@@ -833,6 +833,124 @@ spec:
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
               type: object
+            securityContext:
+              description: SecurityContext holds security configuration that will
+                be applied to pod.
+              properties:
+                fsGroup:
+                  description: "A special supplemental group that applies to all containers
+                    in a pod. Some volume types allow the Kubelet to change the ownership
+                    of that volume to be owned by the pod: \n 1. The owning GID will
+                    be the FSGroup 2. The setgid bit is set (new files created in
+                    the volume will be owned by FSGroup) 3. The permission bits are
+                    OR'd with rw-rw---- \n If unset, the Kubelet will not modify the
+                    ownership and permissions of any volume."
+                  format: int64
+                  type: integer
+                runAsGroup:
+                  description: The GID to run the entrypoint of the container process.
+                    Uses runtime default if unset. May also be set in SecurityContext.  If
+                    set in both SecurityContext and PodSecurityContext, the value
+                    specified in SecurityContext takes precedence for that container.
+                  format: int64
+                  type: integer
+                runAsNonRoot:
+                  description: Indicates that the container must run as a non-root
+                    user. If true, the Kubelet will validate the image at runtime
+                    to ensure that it does not run as UID 0 (root) and fail to start
+                    the container if it does. If unset or false, no such validation
+                    will be performed. May also be set in SecurityContext.  If set
+                    in both SecurityContext and PodSecurityContext, the value specified
+                    in SecurityContext takes precedence.
+                  type: boolean
+                runAsUser:
+                  description: The UID to run the entrypoint of the container process.
+                    Defaults to user specified in image metadata if unspecified. May
+                    also be set in SecurityContext.  If set in both SecurityContext
+                    and PodSecurityContext, the value specified in SecurityContext
+                    takes precedence for that container.
+                  format: int64
+                  type: integer
+                seLinuxOptions:
+                  description: The SELinux context to be applied to all containers.
+                    If unspecified, the container runtime will allocate a random SELinux
+                    context for each container.  May also be set in SecurityContext.  If
+                    set in both SecurityContext and PodSecurityContext, the value
+                    specified in SecurityContext takes precedence for that container.
+                  properties:
+                    level:
+                      description: Level is SELinux level label that applies to the
+                        container.
+                      type: string
+                    role:
+                      description: Role is a SELinux role label that applies to the
+                        container.
+                      type: string
+                    type:
+                      description: Type is a SELinux type label that applies to the
+                        container.
+                      type: string
+                    user:
+                      description: User is a SELinux user label that applies to the
+                        container.
+                      type: string
+                  type: object
+                supplementalGroups:
+                  description: A list of groups applied to the first process run in
+                    each container, in addition to the container's primary GID.  If
+                    unspecified, no groups will be added to any container.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                sysctls:
+                  description: Sysctls hold a list of namespaced sysctls used for
+                    the pod. Pods with unsupported sysctls (by the container runtime)
+                    might fail to launch.
+                  items:
+                    description: Sysctl defines a kernel parameter to be set
+                    properties:
+                      name:
+                        description: Name of a property to set
+                        type: string
+                      value:
+                        description: Value of a property to set
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                windowsOptions:
+                  description: The Windows specific settings applied to all containers.
+                    If unspecified, the options within a container's SecurityContext
+                    will be used. If set in both SecurityContext and PodSecurityContext,
+                    the value specified in SecurityContext takes precedence.
+                  properties:
+                    gmsaCredentialSpec:
+                      description: GMSACredentialSpec is where the GMSA admission
+                        webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                        inlines the contents of the GMSA credential spec named by
+                        the GMSACredentialSpecName field. This field is alpha-level
+                        and is only honored by servers that enable the WindowsGMSA
+                        feature flag.
+                      type: string
+                    gmsaCredentialSpecName:
+                      description: GMSACredentialSpecName is the name of the GMSA
+                        credential spec to use. This field is alpha-level and is only
+                        honored by servers that enable the WindowsGMSA feature flag.
+                      type: string
+                    runAsUserName:
+                      description: The UserName in Windows to run the entrypoint of
+                        the container process. Defaults to the user specified in image
+                        metadata if unspecified. May also be set in PodSecurityContext.
+                        If set in both SecurityContext and PodSecurityContext, the
+                        value specified in SecurityContext takes precedence. This
+                        field is beta-level and may be disabled with the WindowsRunAsUserName
+                        feature flag.
+                      type: string
+                  type: object
+              type: object
             serviceAccountName:
               description: ServiceAccountName configures the service account used
                 on BookKeeper instances

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -262,6 +262,9 @@ type BookkeeperClusterSpec struct {
 	// This is used as suffix for bookkeeper headless service name
 	// +optional
 	HeadlessSvcNameSuffix string `json:"headlessSvcNameSuffix,omitempty"`
+
+	// SecurityContext holds security configuration that will be applied to pod
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 }
 
 // BookkeeperImageSpec defines the fields needed for a BookKeeper Docker image

--- a/pkg/apis/bookkeeper/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/bookkeeper/v1alpha1/zz_generated.deepcopy.go
@@ -141,6 +141,11 @@ func (in *BookkeeperClusterSpec) DeepCopyInto(out *BookkeeperClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -289,6 +289,10 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 		podSpec.InitContainers = bk.Spec.InitContainers
 	}
 
+	if bk.Spec.SecurityContext != nil {
+		podSpec.SecurityContext = bk.Spec.SecurityContext
+	}
+
 	return podSpec
 }
 

--- a/pkg/controller/bookkeepercluster/bookie_test.go
+++ b/pkg/controller/bookkeepercluster/bookie_test.go
@@ -11,6 +11,7 @@
 package bookkeepercluster_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -59,6 +60,7 @@ var _ = Describe("Bookie", func() {
 					},
 				}
 				boolFalse := false
+				id := int64(100)
 				bk.Spec = v1alpha1.BookkeeperClusterSpec{
 					Version:            "0.4.0",
 					ServiceAccountName: "bk-operator",
@@ -107,6 +109,10 @@ var _ = Describe("Bookie", func() {
 							Image:   "dummy-image",
 							Command: []string{"sh", "-c", "ls;pwd"},
 						},
+					},
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser:  &id,
+						RunAsGroup: &id,
 					},
 				}
 				bk.WithDefaults()
@@ -224,6 +230,12 @@ var _ = Describe("Bookie", func() {
 					Ω(podTemplate.Spec.InitContainers[0].Name).To(Equal("testing"))
 					Ω(podTemplate.Spec.InitContainers[0].Image).To(Equal("dummy-image"))
 					Ω(strings.Contains(podTemplate.Spec.InitContainers[0].Command[2], "ls;pwd")).Should(BeTrue())
+				})
+
+				It("should have security context set", func() {
+					podTemplate := bookkeepercluster.MakeBookiePodTemplate(bk)
+					Ω(fmt.Sprintf("%v", *podTemplate.Spec.SecurityContext.RunAsUser)).To(Equal("100"))
+					Ω(fmt.Sprintf("%v", *podTemplate.Spec.SecurityContext.RunAsGroup)).To(Equal("100"))
 				})
 			})
 		})


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Provided option to configure security context.

### Purpose of the change

 Fixes #176

### What the code does
Added a  new spec field securityContext and provided option to configure this field

### How to verify it

Able to configure security context for the pod.
