### PR TITLE
Issue 176: Provide support to run bookkeeper container as non root user

### DIFF
--- a/deploy/crds/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
+++ b/deploy/crds/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
@@ -833,6 +833,9 @@ spec:
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
               type: object
+            runAsPrivilegedUser:
+              description: This is set to run the conatiner as root user
+              type: boolean
             serviceAccountName:
               description: ServiceAccountName configures the service account used
                 on BookKeeper instances

--- a/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
+++ b/pkg/apis/bookkeeper/v1alpha1/bookkeepercluster_types.go
@@ -262,6 +262,9 @@ type BookkeeperClusterSpec struct {
 	// This is used as suffix for bookkeeper headless service name
 	// +optional
 	HeadlessSvcNameSuffix string `json:"headlessSvcNameSuffix,omitempty"`
+
+	//This is set to run the conatiner as root user
+	RunAsPrivilegedUser *bool `json:"runAsPrivilegedUser,omitempty"`
 }
 
 // BookkeeperImageSpec defines the fields needed for a BookKeeper Docker image
@@ -511,6 +514,12 @@ func (s *BookkeeperClusterSpec) withDefaults(bk *BookkeeperCluster) (changed boo
 		changed = true
 		boolTrue := true
 		s.BlockOwnerDeletion = &boolTrue
+	}
+
+	if s.RunAsPrivilegedUser == nil {
+		changed = true
+		boolTrue := true
+		s.RunAsPrivilegedUser = &boolTrue
 	}
 
 	if s.Affinity == nil {

--- a/pkg/apis/bookkeeper/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/bookkeeper/v1alpha1/zz_generated.deepcopy.go
@@ -141,6 +141,11 @@ func (in *BookkeeperClusterSpec) DeepCopyInto(out *BookkeeperClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.RunAsPrivilegedUser != nil {
+		in, out := &in.RunAsPrivilegedUser, &out.RunAsPrivilegedUser
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/bookkeepercluster/bookie.go
+++ b/pkg/controller/bookkeepercluster/bookie.go
@@ -288,6 +288,14 @@ func makeBookiePodSpec(bk *v1alpha1.BookkeeperCluster) *corev1.PodSpec {
 	if bk.Spec.InitContainers != nil {
 		podSpec.InitContainers = bk.Spec.InitContainers
 	}
+	if *bk.Spec.RunAsPrivilegedUser == false {
+		id := int64(1000)
+		podSpec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsUser:  &id,
+			RunAsGroup: &id,
+			FSGroup:    &id,
+		}
+	}
 
 	return podSpec
 }

--- a/pkg/controller/bookkeepercluster/bookie_test.go
+++ b/pkg/controller/bookkeepercluster/bookie_test.go
@@ -11,6 +11,7 @@
 package bookkeepercluster_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -108,6 +109,7 @@ var _ = Describe("Bookie", func() {
 							Command: []string{"sh", "-c", "ls;pwd"},
 						},
 					},
+					RunAsPrivilegedUser: &boolFalse,
 				}
 				bk.WithDefaults()
 			})
@@ -224,6 +226,12 @@ var _ = Describe("Bookie", func() {
 					Ω(podTemplate.Spec.InitContainers[0].Name).To(Equal("testing"))
 					Ω(podTemplate.Spec.InitContainers[0].Image).To(Equal("dummy-image"))
 					Ω(strings.Contains(podTemplate.Spec.InitContainers[0].Command[2], "ls;pwd")).Should(BeTrue())
+				})
+				It("should have security context", func() {
+					podTemplate := bookkeepercluster.MakeBookiePodTemplate(bk)
+					Ω(fmt.Sprintf("%v", *podTemplate.Spec.SecurityContext.RunAsUser)).To(Equal("1000"))
+					Ω(fmt.Sprintf("%v", *podTemplate.Spec.SecurityContext.RunAsGroup)).To(Equal("1000"))
+					Ω(fmt.Sprintf("%v", *podTemplate.Spec.SecurityContext.FSGroup)).To(Equal("1000"))
 				})
 			})
 		})


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Provided support to run bookkeeper container as non-root
### Purpose of the change

Fixes #176

### What the code does

Added a new filed `runAsPrivilegedUser`  in CRD and if it is set to `false` security context  is set with `bookkeeper` as  the user.

### How to verify it

Verified installation  by enabling/disabling `runAsPrivilegedUser`.
Tried upgrading bookkeeper operator followed by bookkeeper
