### PR TITLE
Issue 188: Updating certificate version to v1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,10 +102,10 @@ jobs:
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "helm repo add stable https://charts.helm.sh/stable;helm install stable/nfs-server-provisioner --generate-name"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "kubectl create -f /root/bookkeeper-operator/test/e2e/resources/zookeeper_crd.yaml"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "kubectl create -f /root/bookkeeper-operator/test/e2e/resources/zookeeper.yaml"
-        ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl apply -f \"https://github.com/jetstack/cert-manager/releases/download/v0.14.1/cert-manager.crds.yaml\""
+        ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl apply -f \"https://github.com/jetstack/cert-manager/releases/download/v1.7.0/cert-manager.crds.yaml\""
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "helm repo add jetstack https://charts.jetstack.io"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "helm repo update"
-        ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "kubectl create namespace cert-manager;helm install cert-manager jetstack/cert-manager --namespace cert-manager --version v0.14.1 --wait"
+        ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "kubectl create namespace cert-manager;helm install cert-manager jetstack/cert-manager --namespace cert-manager --version v1.7.0 --wait"
 
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default create -f /root/bookkeeper-operator/deploy/config_map.yaml"
         sleep 30s

--- a/deploy/certificate.yaml
+++ b/deploy/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer-bk
@@ -6,7 +6,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: selfsigned-cert-bk


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Currently, the certificate version used in operator is `v1alpha2` and the support is removed in `k81.22`. Updating the certificate to `v1` version.

### Purpose of the change

 Fixes #188
### What the code does

Updated certificate to `v1` version 

### How to verify it

All e2e should pass
