### PR TITLE
Updating busybox version to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /src/${PROJECT_NAME} \
 # =============================================================================
 FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}alpine:${ALPINE_VERSION} AS final
 
-RUN apk add --upgrade \
+RUN apk update && apk add --upgrade \
     sudo \
     libcap \
     busybox

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,10 @@ RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /src/${PROJECT_NAME} \
 # =============================================================================
 FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}alpine:${ALPINE_VERSION} AS final
 
-RUN apk add --update \
+RUN apk add --upgrade \
     sudo \
-    libcap
+    libcap \
+    busybox
 
 ARG PROJECT_NAME=bookkeeper-operator
 


### PR DESCRIPTION
Signed-off-by: Nishant Gupta <Nishant_Gupta3@dell.com>

### Change log description

Upgrade busybox version to 1.35.0-r17 so as to fix [CVE-2022-30065](https://security.alpinelinux.org/vuln/CVE-2022-30065) and [CVE-2022-28391](https://security.alpinelinux.org/vuln/CVE-2022-28391)

### Purpose of the change

Fixes #215

### What the code does

upgrades busybox version to 1.35.0-r17

### How to verify it

- Pull the latest docker image
- Spawn a container out of that image and go inside the container
- run the command `apk list | grep busybox `to check the installed version of busybox
