### PR TITLE
Issue 120: bookkeeper cluster upgrade is failing intermittently

### DIFF
--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -287,7 +288,7 @@ func (r *BookkeeperClusterReconciler) syncBookkeeperVersion(bk *bookkeeperv1alph
 		log.Infof("updating pod: %s", pod.Name)
 
 		err = r.Client.Delete(context.TODO(), pod)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return false, err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description

Bookkeeper cluster upgrade is failing intermittently. In the case of failure, at the time of processing delete pod request pod is already deleted and is returning the error pod not found, which in turn sets the upgrade state to failed. Due to this reason subsequent pods are not getting updated
### Purpose of the change

 Fixes #120

### What the code does

In the case of deleting pod is failing due to `pod not found` dont return any error. so that upgrade of remaining pods can be performed without any issues

### How to verify it

Performed bookkeeper upgrade multiple times and it was successful
