### PR TITLE
Issue 223: Fixing end to end tests for bookkeeper operator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,6 +118,3 @@ jobs:
       run: |
         SSHKEY=`packet-cli ssh-key get | grep "pravega-travis" | awk '{print $2}' | tr -d ' '`
         echo y | packet-cli ssh-key delete -i $SSHKEY
-        echo y | packet-cli device  delete -i $CLUSTER_ID
-        echo y | packet-cli device  delete -i $CLUSTER_ID1
-        echo y | packet-cli device  delete -i $CLUSTER_ID2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,7 @@ jobs:
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "helm repo update"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "kubectl create namespace cert-manager;helm install cert-manager jetstack/cert-manager --namespace cert-manager --version v1.7.0 --wait"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default create secret docker-registry regcred --docker-server=https://index.docker.io/v1/ --docker-username=testbkop --docker-password=08d50da6-61bd-4953-a2ce-7d7a0e3835bc --docker-email=testbkop@gmail.com"
-        ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer);source /root/.gvm/scripts/gvm;gvm install go1.18 --binary;gvm use go1.18 --default"
+        ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer);source /root/.gvm/scripts/gvm;gvm install go1.18 --binary;gvm use go1.18 --default;git config --global --add safe.directory /root/bookkeeper-operator"
     - name: Running e2e
       run: |
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "cd /root/bookkeeper-operator;source /root/.gvm/scripts/gvm;make test-e2e"
@@ -118,3 +118,6 @@ jobs:
       run: |
         SSHKEY=`packet-cli ssh-key get | grep "pravega-travis" | awk '{print $2}' | tr -d ' '`
         echo y | packet-cli ssh-key delete -i $SSHKEY
+        echo y | packet-cli device  delete -i $CLUSTER_ID
+        echo y | packet-cli device  delete -i $CLUSTER_ID1
+        echo y | packet-cli device  delete -i $CLUSTER_ID2


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description

Bookkeeper operator end to end tests are failing after upgrading go version to `1.18`.
To fix this issue, we need to add git configuration before running e2e tests

### Purpose of the change

 Fixes #223

### What the code does

Added git configuration

### How to verify it

Verified that e2e tests are passing
