### PR TITLE
Issue 220: Bookkeeper cluster upgrade is failing intermittently

### DIFF
--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -274,7 +274,7 @@ func (r *BookkeeperClusterReconciler) syncBookkeeperVersion(bk *bookkeeperv1alph
 		return false, err
 	}
 
-	if ready {
+	if ready && *sts.Spec.Replicas != (int32)(len(pods)) {
 		labels := bk.LabelsForBookkeeperCluster()
 		pod, err := r.getOneOutdatedPod(sts, bk.Status.TargetVersion, labels)
 		if err != nil {

--- a/controllers/upgrade_test.go
+++ b/controllers/upgrade_test.go
@@ -374,9 +374,9 @@ var _ = Describe("Bookkeeper Cluster Version Sync", func() {
 					Ω(b3).Should(Equal(true))
 					Ω(err2).Should(BeNil())
 				})
-				It("Error should not be nil and b4 is false", func() {
+				It("Error should be nil and b4 is false", func() {
 					Ω(b4).Should(Equal(false))
-					Ω(err3).ShouldNot(BeNil())
+					Ω(err3).Should(BeNil())
 				})
 			})
 		})


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description

In some cases, while updating bookkeeper pods, upgrade is failing with error Failed to get outdated pod . When this happens all the bk pods are already updated.

While upgradingbookie pods, even if the pods are updated with new version it takes some time to reflect in the status. So upgrade reconcile loop thinks upgrade is not completed and try to get an outdated pod. Since the pods are already updated, it fails to get outdated pod and makes upgrade as failed.

### Purpose of the change

 Fixes #220

### What the code does

Added an extra check not to update the pod if all the pods are updated to target version

### How to verify it

Verified upgrade couple of times and is working fine