### PR TITLE
Issue 228: Update bookkeeper operator to support k8 1.25

### DIFF
--- a/controllers/bookie.go
+++ b/controllers/bookie.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pravega/bookkeeper-operator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -466,18 +466,18 @@ func MakeBookieConfigMap(bk *v1alpha1.BookkeeperCluster) *corev1.ConfigMap {
 	}
 }
 
-func MakeBookiePodDisruptionBudget(bk *v1alpha1.BookkeeperCluster) *policyv1beta1.PodDisruptionBudget {
+func MakeBookiePodDisruptionBudget(bk *v1alpha1.BookkeeperCluster) *policyv1.PodDisruptionBudget {
 	maxUnavailable := intstr.FromInt(int(bk.Spec.MaxUnavailableBookkeeperReplicas))
-	return &policyv1beta1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
-			APIVersion: "policy/v1beta1",
+			APIVersion: "policy/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      util.PdbNameForBookie(bk.Name),
 			Namespace: bk.Namespace,
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &maxUnavailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: bk.LabelsForBookie(),

--- a/controllers/bookkeepercluster_controller.go
+++ b/controllers/bookkeepercluster_controller.go
@@ -26,7 +26,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -395,7 +395,7 @@ func (r *BookkeeperClusterReconciler) reconcilePdb(bk *bookkeeperv1alpha1.Bookke
 		return err
 	}
 
-	currentPdb := &policyv1beta1.PodDisruptionBudget{}
+	currentPdb := &policyv1.PodDisruptionBudget{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: util.PdbNameForBookie(bk.Name), Namespace: bk.Namespace}, currentPdb)
 	if err != nil {
 		return err
@@ -403,7 +403,7 @@ func (r *BookkeeperClusterReconciler) reconcilePdb(bk *bookkeeperv1alpha1.Bookke
 	return r.updatePdb(currentPdb, pdb)
 }
 
-func (r *BookkeeperClusterReconciler) updatePdb(currentPdb *policyv1beta1.PodDisruptionBudget, newPdb *policyv1beta1.PodDisruptionBudget) (err error) {
+func (r *BookkeeperClusterReconciler) updatePdb(currentPdb *policyv1.PodDisruptionBudget, newPdb *policyv1.PodDisruptionBudget) (err error) {
 
 	if !reflect.DeepEqual(currentPdb.Spec.MaxUnavailable, newPdb.Spec.MaxUnavailable) {
 		currentPdb.Spec.MaxUnavailable = newPdb.Spec.MaxUnavailable
@@ -423,7 +423,7 @@ func (r *BookkeeperClusterReconciler) reconcileService(bk *bookkeeperv1alpha1.Bo
 		return err
 	}
 
-	currentPdb := &policyv1beta1.PodDisruptionBudget{}
+	currentPdb := &policyv1.PodDisruptionBudget{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: util.PdbNameForBookie(bk.Name), Namespace: bk.Namespace}, currentPdb)
 
 	return nil

--- a/controllers/bookkeepercluster_controller_test.go
+++ b/controllers/bookkeepercluster_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/pravega/bookkeeper-operator/pkg/controller/config"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	. "github.com/onsi/ginkgo"
@@ -23,7 +24,6 @@ import (
 	"github.com/pravega/bookkeeper-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -47,7 +47,7 @@ var _ = Describe("BookkeeperCluster Controller", func() {
 			req reconcile.Request
 			res reconcile.Result
 			b   *v1alpha1.BookkeeperCluster
-		//	ctx context.Context
+			//	ctx context.Context
 		)
 
 		BeforeEach(func() {
@@ -136,20 +136,20 @@ var _ = Describe("BookkeeperCluster Controller", func() {
 				)
 				BeforeEach(func() {
 					res, err = r.Reconcile(ctx, req)
-					currentpdb := &policyv1beta1.PodDisruptionBudget{}
+					currentpdb := &policyv1.PodDisruptionBudget{}
 					pdbname := fmt.Sprintf("%s-bookie", b.Name)
 					r.Client.Get(context.TODO(), types.NamespacedName{Name: pdbname, Namespace: b.Namespace}, currentpdb)
 					maxUnavailable := intstr.FromInt(3)
-					newpdb := &policyv1beta1.PodDisruptionBudget{
+					newpdb := &policyv1.PodDisruptionBudget{
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "PodDisruptionBudget",
-							APIVersion: "policy/v1beta1",
+							APIVersion: "policy/v1",
 						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "test-name",
 							Namespace: b.Namespace,
 						},
-						Spec: policyv1beta1.PodDisruptionBudgetSpec{
+						Spec: policyv1.PodDisruptionBudgetSpec{
 							MaxUnavailable: &maxUnavailable,
 							Selector: &metav1.LabelSelector{
 								MatchLabels: b.LabelsForBookie(),


### PR DESCRIPTION
### Change log description

Changed the poddisruption budget version from `v1beta1` to `v1`

### Purpose of the change

Fixes #228

### What the code does

To support k8 1.25, updated pod disruption budget

### How to verify it

All end to end tests should pass
