### PR TITLE
Issue 220: Fix for intermittent bookkeeper cluster upgrade failure

### DIFF
--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -282,6 +282,14 @@ func (r *BookkeeperClusterReconciler) syncBookkeeperVersion(bk *bookkeeperv1alph
 		}
 
 		if pod == nil {
+			pods, err := r.getStsPodsWithVersion(sts, bk.Status.TargetVersion)
+			if err != nil {
+				return false, err
+			}
+			if *sts.Spec.Replicas == (int32)(len(pods)) {
+				log.Infof("All bookkeeper pods are updated")
+				return false, nil
+			}
 			return false, fmt.Errorf("could not obtain outdated pod")
 		}
 


### PR DESCRIPTION
### Change log description
Fixing intermittent upgrade failure of bookkeeper.
Added some more conditions to handle error scenarios
### Purpose of the change

Fixes #220

### What the code does

while during bookkeeper  update, it fails to get the pod sometimes. Issue is happening because while it tries to get an outdated pod, it has already updated. So added more checks to post error only if all pods were not updated
### How to verify it

Peformed upgrade multiple time and issue is not seen
